### PR TITLE
Improved logging, new ns-rsyslog package

### DIFF
--- a/config/ns-rsyslog.conf
+++ b/config/ns-rsyslog.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_ns-rsyslog=y

--- a/config/rsyslog.conf
+++ b/config/rsyslog.conf
@@ -1,0 +1,9 @@
+# Enable rsyslog
+CONFIG_PACKAGE_rsyslog=y
+CONFIG_RSYSLOG_imfile=y
+CONFIG_PACKAGE_libestr=y
+CONFIG_PACKAGE_libfastjson=y
+
+# Disable logd and logread
+CONFIG_DEFAULT_logd=n
+CONFIG_PACKAGE_logd=n

--- a/files/etc/uci-defaults/99-nextsec-rsyslog
+++ b/files/etc/uci-defaults/99-nextsec-rsyslog
@@ -1,0 +1,2 @@
+/etc/init.d/rsyslog stop
+/etc/init.d/rsyslog disable

--- a/packages/ns-rsyslog/Makefile
+++ b/packages/ns-rsyslog/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2022 Nethesis
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+ 
+PKG_NAME:=ns-rsyslog
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=$(AUTORELEASE)
+ 
+PKG_BUILD_DIR:=$(BUILD_DIR)/ns-rsyslog-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
+PKG_LICENSE:=GPL-3.0-only
+
+include $(INCLUDE_DIR)/package.mk
+ 
+define Package/ns-rsyslog
+	SECTION:=base
+	CATEGORY:=NextSecurity
+	TITLE:=NextSecurity UCI configuration for rsyslog
+	URL:=https://github.com/NethServer/nextsecurity-controller/
+	DEPENDS:=+rsyslog
+	PKGARCH:=all
+endef
+ 
+define Package/ns-rsyslog/description
+	UCI configuration support for rsyslog
+endef
+
+define Package/ns-rsyslog/conffiles
+	/etc/config/rsyslog
+endef
+
+# this is required, otherwise compile will fail
+define Build/Compile
+endef
+
+define Package/ns-rsyslog/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_BIN) ./files/ns-rsyslog.init $(1)/etc/init.d/ns-rsyslog
+	$(INSTALL_CONF) ./files/config $(1)/etc/config/rsyslog
+endef
+ 
+$(eval $(call BuildPackage,ns-rsyslog))

--- a/packages/ns-rsyslog/files/config
+++ b/packages/ns-rsyslog/files/config
@@ -1,0 +1,12 @@
+config syslog syslog
+    option tcp_input '0'
+    option tcp_input_port '514'
+    option udp_input '0'
+    option udp_input_port '514'
+    option default_template 'RSYSLOG_TraditionalFileFormat'
+    list modules 'imuxsock'
+    list modules 'imklog'
+
+config selector default
+	option source '*.*'
+	option destination '/var/log/messages'

--- a/packages/ns-rsyslog/files/ns-rsyslog.init
+++ b/packages/ns-rsyslog/files/ns-rsyslog.init
@@ -1,0 +1,104 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2022 Nethesis
+
+START=20
+
+USE_PROCD=1
+
+UCI_CONF="rsyslog"
+CONFIG_FILE="/etc/rsyslog.conf"
+
+modules=""
+selectors=""
+forwarders=""
+
+handle_selector() {
+    local config="$1"
+    local src
+    local dst
+
+    config_get src ${config} source
+    config_get dst ${config} destination
+    if [ ${src} != "" ] && [ "$dst" != "" ]; then
+        selectors="${selectors}\n${src}\t${dst}\n"
+    fi
+}
+
+handle_forwarder() {
+    local config="$1"
+    local src
+    local target
+    local protocol
+    local port
+    local rfc
+    local opts
+
+    config_get src ${config} source
+    config_get target ${config} target
+    config_get protocol ${config} protocol "udp"
+    config_get port ${config} port "514"
+    config_get rfc ${config} rfc "3164"
+
+    if [ "$rfc" == "5424" ]; then
+        opts='Template="RSYSLOG_SyslogProtocol23Format" TCP_Framing="octet-counted"'
+    fi
+
+    if [ ${src} != "" ] && [ "${target}" != "" ]; then
+        action="action(type=\"omfwd\" target=\"$target\" port=\"$port\" protocol=\"$protocol\" $opts action.resumeRetryCount=\"100\" queue.type=\"linkedList\" queue.size=\"10000\")"
+       forwarders="${forwarders}\n${src}\t${action}\n"
+    fi
+}
+
+
+expand_config() {
+    local input_t=""
+    local input_u=""
+    
+    config_load ${UCI_CONF}
+    config_list_foreach syslog modules handle_module
+    config_get_bool tcp_input syslog tcp_input
+    if [ ${tcp_input} -eq 1 ]; then
+        modules="${modules} imtcp"
+        config_get tcp_port syslog tcp_input_port
+        input_t="input(type=\"imtcp\" port=\"${tcp_port}\")"
+    fi
+
+    config_get_bool udp_input syslog udp_input
+    if [ ${udp_input} -eq 1 ]; then
+        modules="${modules} imudp"
+        config_get udp_port syslog udp_input_port
+        input_u="input(type=\"imudp\" port=\"${udp_port}\")"
+
+    fi
+    config_get template syslog default_template
+    config_foreach handle_selector selector
+    config_foreach handle_forwarder forwarder
+
+    > ${CONFIG_FILE}
+    for m in ${modules}; do
+        echo "module(load=\"${m}\")" >> ${CONFIG_FILE}
+    done
+    echo ${input_t} >> ${CONFIG_FILE}
+    echo ${input_u} >> ${CONFIG_FILE}
+    echo "\$ActionFileDefaultTemplate ${template}" >> ${CONFIG_FILE}
+    echo -e ${selectors} >> ${CONFIG_FILE}
+    echo -e ${forwarders} >> ${CONFIG_FILE}
+}
+
+handle_module() {
+    local module="$1"
+    modules="${modules} $module"
+}
+
+start_service() {
+    expand_config
+    procd_open_instance
+    procd_set_param command /usr/sbin/rsyslogd -n
+    procd_close_instance
+}
+
+
+service_triggers()
+{
+    procd_add_reload_trigger ${UCI_CONF}
+}


### PR DESCRIPTION
- Add ns-rsyslog
- Remove logd and logread
- Support dynamic configuration with UCI

Default rsyslog configuration:
- send everything to /var/log/messages
- UDP and TCP receiver are disabled

Setup forwarding to promtail:
```
uci set rsyslog.promtail=forwarder
uci set rsyslog.promtail.source=*.*
uci set rsyslog.promtail.protocol=tcp
uci set rsyslog.promtail.port=10514
uci set rsyslog.promtail.rfc=5424
uci set rsyslog.promtail.target=192.168.122.2
uci commit
/etc/init.d/rsyslog restart
```

Setup forwarding to another rsyslog:
```
uci set rsyslog.promtail=forwarder
uci set rsyslog.promtail.source=*.*
uci set rsyslog.promtail.protocol=udp
uci set rsyslog.promtail.port=10514
uci set rsyslog.promtail.rfc=3164
uci set rsyslog.promtail.target=192.168.122.2
uci commit
/etc/init.d/rsyslog restart
```

Replaces #13 