### PR TITLE
config: open UI from WAN

### DIFF
--- a/files/etc/uci-defaults/99-nextsec-webui
+++ b/files/etc/uci-defaults/99-nextsec-webui
@@ -1,0 +1,9 @@
+uci batch <<EOI
+add firewall rule
+set firewall.@rule[-1].name='Allow-UI-from-WAN'
+set firewall.@rule[-1].proto='tcp'
+set firewall.@rule[-1].src='wan'
+set firewall.@rule[-1].dest_port='443'
+set firewall.@rule[-1].target='ACCEPT'
+commit
+EOI


### PR DESCRIPTION
Simplify first configuration.
The UI should then guide the user to remove the firewall rule.