### PR TITLE
Migration draft package

### DIFF
--- a/config/ns-migration.conf
+++ b/config/ns-migration.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_ns-migration=y

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -21,6 +21,7 @@ define Package/ns-migration
 	CATEGORY:=NextSecurity
 	TITLE:=NS7 2 NextSecurity migration
 	URL:=https://github.com/NethServer/nextsecurity/tree/master/packages/ns-migration
+	DEPENDS:=+python3-uci
 	PKGARCH:=all
 endef
  

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-migration
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-migration-$(PKG_VERSION)
 

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -36,9 +36,13 @@ define Package/ns-migration/install
 	$(INSTALL_DIR) $(1)/usr/share/ns-migration
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/ns-import $(1)/usr/sbin/ns-import
-	$(INSTALL_BIN) ./files/scripts/network $(1)/usr/share/ns-migration/network
-	$(INSTALL_BIN) ./files/scripts/dhcp $(1)/usr/share/ns-migration/dhcp
-	$(INSTALL_BIN) ./files/scripts/dns $(1)/usr/share/ns-migration/dns
+	$(INSTALL_BIN) ./files/scripts/network $(1)/usr/share/ns-migration/
+	$(INSTALL_BIN) ./files/scripts/dhcp $(1)/usr/share/ns-migration/
+	$(INSTALL_BIN) ./files/scripts/dns $(1)/usr/share/ns-migration/
+	$(INSTALL_BIN) ./files/scripts/routes $(1)/usr/share/ns-migration/
+	$(INSTALL_BIN) ./files/scripts/time $(1)/usr/share/ns-migration/
+	$(INSTALL_BIN) ./files/scripts/ssh $(1)/usr/share/ns-migration/
+	$(INSTALL_DATA) ./files/scripts/fwutils.py $(1)/usr/share/ns-migration/
 endef
  
 $(eval $(call BuildPackage,ns-migration))

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -39,6 +39,7 @@ define Package/ns-migration/install
 	$(INSTALL_BIN) ./files/ns-import $(1)/usr/sbin/ns-import
 	$(INSTALL_BIN) ./files/scripts/network $(1)/usr/share/ns-migration/network
 	$(INSTALL_BIN) ./files/scripts/dhcp $(1)/usr/share/ns-migration/dhcp
+	$(INSTALL_BIN) ./files/scripts/dns $(1)/usr/share/ns-migration/dns
 endef
  
 $(eval $(call BuildPackage,ns-migration))

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -1,7 +1,6 @@
 #
-# Copyright (C) 2022 Nethesis
-#
-# This is free software, licensed under the GNU General Public License v3.
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
 #
 
 include $(TOPDIR)/rules.mk

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2022 Nethesis
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+ 
+PKG_NAME:=ns-migration
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=$(AUTORELEASE)
+ 
+PKG_BUILD_DIR:=$(BUILD_DIR)/ns-migration-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
+PKG_LICENSE:=GPL-3.0-only
+
+include $(INCLUDE_DIR)/package.mk
+ 
+define Package/ns-migration
+	SECTION:=base
+	CATEGORY:=NextSecurity
+	TITLE:=NS7 2 NextSecurity migration
+	URL:=https://github.com/NethServer/nextsecurity/tree/master/packages/ns-migration
+	PKGARCH:=all
+endef
+ 
+define Package/ns-migration/description
+	Import NS7 firewall configuration
+endef
+
+# this is required, otherwise compile will fail
+define Build/Compile
+endef
+
+define Package/ns-migration/install
+	$(INSTALL_DIR) $(1)/usr/share/ns-migration
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/ns-import $(1)/usr/sbin/ns-import
+	$(INSTALL_BIN) ./files/scripts/network $(1)/usr/share/ns-migration/network
+endef
+ 
+$(eval $(call BuildPackage,ns-migration))

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -38,6 +38,7 @@ define Package/ns-migration/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/ns-import $(1)/usr/sbin/ns-import
 	$(INSTALL_BIN) ./files/scripts/network $(1)/usr/share/ns-migration/network
+	$(INSTALL_BIN) ./files/scripts/dhcp $(1)/usr/share/ns-migration/dhcp
 endef
  
 $(eval $(call BuildPackage,ns-migration))

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -43,6 +43,7 @@ define Package/ns-migration/install
 	$(INSTALL_BIN) ./files/scripts/routes $(1)/usr/share/ns-migration/
 	$(INSTALL_BIN) ./files/scripts/time $(1)/usr/share/ns-migration/
 	$(INSTALL_BIN) ./files/scripts/ssh $(1)/usr/share/ns-migration/
+	$(INSTALL_BIN) ./files/scripts/subscription $(1)/usr/share/ns-migration/
 	$(INSTALL_DATA) ./files/scripts/fwutils.py $(1)/usr/share/ns-migration/
 endef
  

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -21,7 +21,7 @@ define Package/ns-migration
 	CATEGORY:=NextSecurity
 	TITLE:=NS7 2 NextSecurity migration
 	URL:=https://github.com/NethServer/nextsecurity/tree/master/packages/ns-migration
-	DEPENDS:=+python3-uci
+	DEPENDS:=+python3-nextsec
 	PKGARCH:=all
 endef
  
@@ -44,7 +44,7 @@ define Package/ns-migration/install
 	$(INSTALL_BIN) ./files/scripts/time $(1)/usr/share/ns-migration/
 	$(INSTALL_BIN) ./files/scripts/ssh $(1)/usr/share/ns-migration/
 	$(INSTALL_BIN) ./files/scripts/subscription $(1)/usr/share/ns-migration/
-	$(INSTALL_DATA) ./files/scripts/fwutils.py $(1)/usr/share/ns-migration/
+	$(INSTALL_DATA) ./files/scripts/nsmigration.py $(1)/usr/share/ns-migration/
 endef
  
 $(eval $(call BuildPackage,ns-migration))

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -6,3 +6,16 @@ Usage example:
 ```
 ns-import export.tar.gz
 ```
+
+The `ns-import` will:
+- explode the archive inside a temporary directory
+- invoke all the scripts inside `/usr/share/firewall-import/` directory
+- pass the temporary directory as argument to each script
+
+Scripts can also be invoked manually after extracting the archive.
+Example:
+```
+cd /tmp
+tar xvzf export.tar.gz
+/usr/share/firewall-import/network /tmp/export
+```

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -1,0 +1,8 @@
+# ns-migration
+
+ns-migration imports the configuration from NethServer 7.
+
+Usage example:
+```
+firewall-import export.tar.gz
+```

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -4,5 +4,5 @@ ns-migration imports the configuration from NethServer 7.
 
 Usage example:
 ```
-firewall-import export.tar.gz
+ns-import export.tar.gz
 ```

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -19,3 +19,11 @@ cd /tmp
 tar xvzf export.tar.gz
 /usr/share/firewall-import/network /tmp/export
 ```
+
+## network
+
+Differences since NS7:
+
+- source NAT are connected to `wan` outbound zone and not to a specific interface;
+  this configuration can be changed by setting `src` option to `*` and adding `device` option set to the WAN physical ethernet interface
+  

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -26,4 +26,7 @@ Differences since NS7:
 
 - source NAT are connected to `wan` outbound zone and not to a specific interface;
   this configuration can be changed by setting `src` option to `*` and adding `device` option set to the WAN physical ethernet interface
-  
+ 
+## dhcp
+
+- TFTP options are migrated, but not the content of the tftp_root directory. To re-enable the service make sure to setup `tftp_root` option

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -1,10 +1,19 @@
 # ns-migration
 
-ns-migration imports the configuration from NethServer 7.
+ns-migration imports the configuration from NethServer 7 (NS7).
+
+Before proceed, make sure to export NS7 configuration using [nethserver-firwall-migration](https://github.com/NethServer/nethserver-firewall-migration/) package. 
+
+## Usage
+
+The main command is `ns-import`:
+```
+./ns-import [-q] [-m oldmac=newmac] <exported_archive>
+```
 
 Usage example:
 ```
-ns-import export.tar.gz
+ns-import -m 'ae:12:3b:19:0a:2a=0b:64:31:69:ae:8a' export.tar.gz
 ```
 
 The `ns-import` will:
@@ -19,6 +28,21 @@ cd /tmp
 tar xvzf export.tar.gz
 /usr/share/firewall-import/network /tmp/export
 ```
+
+The `ns-import` script is verbose by default, use the `-q` option to suppress output to standard output.
+
+### Remapping interfaces
+
+When importing the configuration from an old machine to a new one, you need to remap
+network interface hardware addresses.
+
+Usage example:
+```
+ns-import -m 'ae:12:3b:19:0a:2a=0b:64:31:69:ae:8a' export.tar.gz
+```
+
+The `-m` option will be used by migration scripts to move the configuration from the old network
+interface (`ae:12:3b:19:0a:2a`) to the new one (`0b:64:31:69:ae:8a`).
 
 ## network
 

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -8,7 +8,7 @@ Before proceed, make sure to export NS7 configuration using [nethserver-firwall-
 
 The main command is `ns-import`:
 ```
-./ns-import [-q] [-m oldmac=newmac] <exported_archive>
+ns-import [-q] [-m oldmac=newmac] <exported_archive>
 ```
 
 Usage example:
@@ -44,13 +44,187 @@ ns-import -m 'ae:12:3b:19:0a:2a=0b:64:31:69:ae:8a' export.tar.gz
 The `-m` option will be used by migration scripts to move the configuration from the old network
 interface (`ae:12:3b:19:0a:2a`) to the new one (`0b:64:31:69:ae:8a`).
 
-## network
+## Network
+
+The `network` script will reset default configuration by deleting all wan and lan devices with associated firewall zones.
+It will import:
+
+- Ethernet interfaces
+- VLAN devices
+- Aliases
+- Firewall roles using firewall zones and forwarding
+- Source NAT rules
 
 Differences since NS7:
 
 - source NAT are connected to `wan` outbound zone and not to a specific interface;
   this configuration can be changed by setting `src` option to `*` and adding `device` option set to the WAN physical ethernet interface
- 
-## dhcp
+- `green` zone has been renamed to `lan`
+- `red` zone has been renamed to `wan`
 
-- TFTP options are migrated, but not the content of the tftp_root directory. To re-enable the service make sure to setup `tftp_root` option
+The following configuration are still not imported:
+
+- bridges
+- bonds
+- PPPoE
+ 
+## Date and time
+
+The `time` script will import:
+
+- timezone
+- NTP client status (enabled/disabled)
+- NTP server list
+
+If NTP client is disabled on NS7, you must re-configure the time manually after the import.
+
+## DHCP
+
+The `dhcp` script will import:
+
+- global options like DHCP max lease time
+- DHCP servers
+- DHCP static leases (reservations)
+
+## DNS 
+
+The `dns` script will import:
+
+- system FQDN
+- global DNS configuration like local domain and DNS forwarders
+- static hosts
+- static wild card hosts
+
+TFTP options are migrated, but not the content of the tftp_root directory. To re-enable the service make sure to setup `tftp_root` option.
+
+## Static routes
+
+The `routes` script will import:
+
+- all static routes
+
+Only static routes associated to physical interfaces will be imported.
+
+## Port forwarding
+
+The `redirect` script will import:
+
+- all port forwards
+
+If `HairpinNat` option was enabled on NS7, all imported port forward will have hairpin enabled (see `reflection` option).
+
+## Firewall rules
+
+The `rules` script will import:
+
+- all firewall rules
+
+The following NS7 features are still not imported:
+
+- rules using NDPI services
+
+Differences since NS7:
+
+- zones are migrated as CIDR networks
+- rules using non-existing zones will be disabled
+- NAT helpers are disabled by default
+- wan interfaces will accept extra traffic:
+
+  - DHCP replies (`Allow-DHCP-Renew` and `Allow-DHCPv6` rules)
+  - Ping (`Allow-Ping`, `Allow-ICMPv6-Input` and `Allow-ICMPv6-Forward` rules)
+  - IGMP traffic (`Allow-IGMP` rule)
+  - Multicast traffic (`Allow-MLD` rule)
+  - IPsec (`Allow-ISAKMP` and `Allow-IPSec-ESP` rules)
+
+The following NS7 features will not be migrated:
+
+- `State` option for rules: rules will be applied only to new connections
+- `ExternalPing` option: ping to wan is always permitted; disable corresponding rules to block it (see above)
+- `MACValidation` (MAC Binding), you can replicate the same behavior by deleting the forwarding from lan to wan and then creating 
+   a rule accepting traffic from a list of MAC addresses (`src_mac` option, see [suggested solution](https://forum.openwrt.org/t/block-all-except-mac-address-list/124879/8?))
+- `Policy` option: `strict` policy will be converted to `permissive`; you can replicate the same behavior by deleting forwarding rules for involved zones
+- `SipAlg` option: application level gateway (ALG) are disabled by default; if you need to enable NAT helper see [suggested solution](https://forum.openwrt.org/t/solved-incoming-calls-not-reaching-hosts-on-the-network/77568/2)
+
+## MultiWAN
+
+The `wan` script will import:
+
+- multiwan mode (balance/backup)
+- provider weight
+- IP to check WAN connectivity
+- divert rules
+
+The following NS7 features will not be migrated:
+
+- time matches for rules (not supported by mwan3)
+- mail notification on WAN status change
+- `MaxNumberPacketLoss` and `MaxPercentPacketLoss` tracking options
+
+Differences since NS7:
+
+- rules are presented in reverse order
+
+After the migration you should tune tracking options for each wan interface.
+
+## QoS
+
+Not implemented yet.
+
+## OpenVPN
+
+The `openvpn` script will import:
+
+- CA, server and users certificates and keys
+- IP address reservation
+- user names with enabled/disabled status
+
+The following NS7 features are still not migrated:
+- OpenVPN tunnels
+- authentication based user and password
+- authentication certificate and password
+- authentication certificate and One Time password (OTP)
+- mail notification
+
+Existing data from connection database are not imported.
+
+See also [ns-openvpn](../ns-openvpn).
+
+## IPSec
+
+Not implemented yet.
+
+## Threat shield
+
+The `threat_shield` script will import:
+
+- IP blacklist configuration with status (enabled/disabled), categories and local white list
+- DNS blacklist configuration with status (enabled/disabled), categories and host bypass
+
+If the categories comes from a community repositories, you should reconfigure after the import.
+
+See also [ns-threat_shield](../ns-threat_shield).
+
+## Subscription
+
+The `subscription` script will import:
+
+- system identifier
+- system secret
+
+## Other features
+
+The following features will be migrated in the upcoming months:
+
+- Hotspot (Dedalo)
+- Cloud DNS filter (Flashstart)
+- IPSec tunnels
+
+The following features are not migrated to NextSecurity:
+
+- Web proxy (Squid) and filter (ufdbGuard)
+- IPS (Suricata) and IPS alerts (EveBox)
+- UPS monitoring (NUT)
+- System statistics (Collectd)
+- Reports (Dante)
+- Bandwidth monitor (ntopng)
+- Fail2ban

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+function usage {
+    echo "$0 <exported_archive>"
+    exit 1
+}
+
+if [ -z "$1" ]; then
+    usage    
+fi
+
+if [ ! -f $1 ]; then
+    echo "No such file or directory: '$1'"
+    exit 1
+fi
+
+tmp_dir=$(mktemp -d)
+work_dir=$(pwd)
+archive="$work_dir/$1"
+cd $tmp_dir
+tar xvzf "$archive"
+cd $work_dir
+
+for f in $(find /usr/share/firewall-import/ -type f)
+do
+    $f "$tmp_dir/export"
+done
+
+rm -rf $tmp_dir

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -23,7 +23,7 @@ tar xvzf "$archive"
 cd $work_dir
 
 # Execute all scripts
-for f in $(find /usr/share/firewall-import/ -type f)
+for f in $(find /usr/share/ns-migration/ -type f)
 do
     $f "$tmp_dir/export"
 done

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -47,4 +47,5 @@ service firewall restart
 service dnsmasq restart
 service dropbear restart
 service system restart
+service cron restart
 service sysntpd restart

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -14,6 +14,7 @@ if [ ! -f $1 ]; then
     exit 1
 fi
 
+# Prepare target directories and explode archive
 tmp_dir=$(mktemp -d)
 work_dir=$(pwd)
 archive="$work_dir/$1"
@@ -21,9 +22,15 @@ cd $tmp_dir
 tar xvzf "$archive"
 cd $work_dir
 
+# Execute all scripts
 for f in $(find /usr/share/firewall-import/ -type f)
 do
     $f "$tmp_dir/export"
 done
 
 rm -rf $tmp_dir
+
+# Restart services
+service network restart
+service firewall restart
+service dnsmasq restart

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
 function usage {
     echo "$0 <exported_archive>"
     exit 1

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -46,3 +46,5 @@ service network restart
 service firewall restart
 service dnsmasq restart
 service dropbear restart
+service system restart
+service sysntpd restart

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -49,3 +49,4 @@ service dropbear restart
 service system restart
 service cron restart
 service sysntpd restart
+service ns-plug restart

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -17,15 +17,21 @@ fi
 # Prepare target directories and explode archive
 tmp_dir=$(mktemp -d)
 work_dir=$(pwd)
-archive="$work_dir/$1"
+
+# Find absolute path of the archive
+archive=$(cd "$(dirname -- "$1")" >/dev/null; pwd -P)/$(basename -- "$1")
+
+# Explode the archive
 cd $tmp_dir
-tar xvzf "$archive"
+tar xzf "$archive"
 cd $work_dir
 
 # Execute all scripts
 for f in $(find /usr/share/ns-migration/ -type f)
 do
-    $f "$tmp_dir/export"
+    if [ -x "$f" ]; then
+        "$f" "$tmp_dir/export"
+    fi
 done
 
 rm -rf $tmp_dir

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -45,3 +45,4 @@ rm -rf $tmp_dir
 service network restart
 service firewall restart
 service dnsmasq restart
+service dropbear restart

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -5,16 +5,26 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-function usage {
+usage() {
     echo "$0 <exported_archive>"
     exit 1
 }
+
+try_restart() {
+    service=$1
+    if service "$service" running; then
+        echo "service $service restart"
+    else
+        echo "service $service start"
+    fi
+}
+
 
 if [ -z "$1" ]; then
     usage    
 fi
 
-if [ ! -f $1 ]; then
+if [ ! -f "$1" ]; then
     echo "No such file or directory: '$1'"
     exit 1
 fi
@@ -44,13 +54,13 @@ rm -rf $tmp_dir
 # Restart services
 service network restart
 service firewall restart
-service dnsmasq restart
-service dropbear restart
 service system restart
-service cron restart
-service sysntpd restart
-service ns-plug restart
-service ts-dns restart
 service ts-ip restart
-service openvpn restart
-service mwan3 restart
+try_restart dnsmasq
+try_restart dropbear
+try_restart cron
+try_restart sysntpd
+try_restart ns-plug
+try_restart ts-dns
+try_restart openvpn
+try_restart mwan3

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -50,3 +50,5 @@ service system restart
 service cron restart
 service sysntpd restart
 service ns-plug restart
+service ts-dns restart
+service ts-ip restart

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -53,3 +53,4 @@ service ns-plug restart
 service ts-dns restart
 service ts-ip restart
 service openvpn restart
+service mwan3 restart

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -6,7 +6,7 @@
 #
 
 usage() {
-    echo "$0 <exported_archive>"
+    echo "$0 [-q] [-m oldmac=newmac] <exported_archive> "
     exit 1
 }
 
@@ -19,15 +19,30 @@ try_restart() {
     fi
 }
 
+maps=''
+quiet=""
 
-if [ -z "$1" ]; then
+while getopts "qm:" opt
+do
+    case $opt in
+        m) maps="$maps --map ${OPTARG}"  ;;
+        q) quiet="--quiet"  ;;
+        *) exit 1;;   # DEFAULT
+    esac
+done
+
+shift $(($OPTIND - 1))
+archive=$1
+
+if [ -z "$archive" ]; then
     usage    
 fi
 
-if [ ! -f "$1" ]; then
+if [ ! -f "$archive" ]; then
     echo "No such file or directory: '$1'"
     exit 1
 fi
+
 
 # Prepare target directories and explode archive
 tmp_dir=$(mktemp -d)
@@ -45,7 +60,7 @@ cd $work_dir
 for f in $(find /usr/share/ns-migration/ -type f)
 do
     if [ -x "$f" ]; then
-        "$f" "$tmp_dir/export"
+        "$f" $quiet $maps "$tmp_dir/export"
     fi
 done
 

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -52,3 +52,4 @@ service sysntpd restart
 service ns-plug restart
 service ts-dns restart
 service ts-ip restart
+service openvpn restart

--- a/packages/ns-migration/files/scripts/dhcp
+++ b/packages/ns-migration/files/scripts/dhcp
@@ -26,8 +26,23 @@ for s in data['servers']:
         u.set("dhcp", sname, "domain", s["domain"])
     rcounter = rcounter - 1
 
+
+# Check if an IP address has been already reserved
+def already_reserved(ip):
+    for section in u.get_all('dhcp'):
+        if u.get('dhcp', section) != 'host':
+            continue
+        if u.get('dhcp', section, 'ip') == ip:
+            return True
+    return False
+
 # Create static leases
 for r in data['reservations']:
+    # DHCP will refuse to start if there are multiple static leases with the same IP address
+    if already_reserved(r['ip']):
+        fwutils.vprint(f'Skipping duplicate lease {r["name"]}')
+        continue
+
     rname = fwutils.sanitize(r["name"])
     fwutils.vprint(f'Creating static lease {rname}')
     u.set("dhcp", rname, "host") # create named record

--- a/packages/ns-migration/files/scripts/dhcp
+++ b/packages/ns-migration/files/scripts/dhcp
@@ -1,46 +1,8 @@
 #!/usr/bin/python3
 
-import sys
-import json
-import argparse
-import subprocess
-from glob import glob
-from euci import EUci
+import fwutils
 
-def get_interface_name(euci, interfaces, hwaddr):
-    name = ""
-    for interface in interfaces:
-        if interface["address"] == hwaddr:
-            name = interface["ifname"]
-        if name:
-            break
-
-    for section in u.get("network"):
-        if  u.get("network", section) == "interface" and (u.get("network", section, "device") == name):
-            return section
-
-    return None
-
-def sanitize(name):
-    return name.translate({ord(i): '_' for i in ' -.'})
-
-# Parse command line arguments
-parser = argparse.ArgumentParser(description="Import network and basic firewall configuration")
-parser.add_argument("--quiet", "-q", action="store_true", help="don't print executed actions to stdout")
-parser.add_argument("export_dir", nargs=1, help="export directory with uncompressed files")
-args = parser.parse_args()
-
-vprint = print if not args.quiet else lambda *a, **k: None
-
-# Read NS7 network configurations
-f = open(f'{args.export_dir[0]}/dhcp.json')
-data = json.load(f)
-f.close()
-
-# Initialize UCI pointer
-u = EUci()
-
-local_interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
+(u, data) = fwutils.init("dhcp.json")
 
 # Set global options
 for section in u.get("dhcp"):
@@ -50,9 +12,9 @@ for section in u.get("dhcp"):
 # Setup DHCP ranges
 rcounter = len(data['servers'])
 for s in data['servers']:
-    iname = get_interface_name(u, local_interfaces, s["hwaddr"])
+    iname = fwutils.get_interface_name(u, s["hwaddr"])
     sname = f'dhcp{rcounter}'
-    vprint(f'Creating DHCP server {sname} on {iname}')
+    fwutils.vprint(f'Creating DHCP server {sname} on {iname}')
     u.set("dhcp", sname, "dhcp") # create named record
     u.set("dhcp", sname, "interface", iname)
     u.set("dhcp", sname, "leasetime", s["leasetime"])
@@ -66,10 +28,10 @@ for s in data['servers']:
 
 # Create static leases
 for r in data['reservations']:
-    rname = sanitize(r["name"])
-    vprint(f'Creating static lease {rname}')
+    rname = fwutils.sanitize(r["name"])
+    fwutils.vprint(f'Creating static lease {rname}')
     u.set("dhcp", rname, "host") # create named record
-    #u.set("network", aname, "device", u.get("network", sanitize(a["device"]), "device"))
+    #u.set("network", aname, "device", u.get("network", fwutils.sanitize(a["device"]), "device"))
     u.set("dhcp", rname, "name", rname)
     u.set("dhcp", rname, "mac", r['mac'])
     u.set("dhcp", rname, "ip", r['ip'])

--- a/packages/ns-migration/files/scripts/dhcp
+++ b/packages/ns-migration/files/scripts/dhcp
@@ -1,5 +1,10 @@
 #!/usr/bin/python3
 
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
 import fwutils
 
 (u, data) = fwutils.init("dhcp.json")

--- a/packages/ns-migration/files/scripts/dhcp
+++ b/packages/ns-migration/files/scripts/dhcp
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+
+import sys
+import json
+import argparse
+import subprocess
+from glob import glob
+from euci import EUci
+
+def get_interface_name(euci, interfaces, hwaddr):
+    name = ""
+    for interface in interfaces:
+        if interface["address"] == hwaddr:
+            name = interface["ifname"]
+        if name:
+            break
+
+    for section in u.get("network"):
+        if  u.get("network", section) == "interface" and (u.get("network", section, "device") == name):
+            return section
+
+    return None
+
+def sanitize(name):
+    return name.translate({ord(i): '_' for i in ' -.'})
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Import network and basic firewall configuration")
+parser.add_argument("--quiet", "-q", action="store_true", help="don't print executed actions to stdout")
+parser.add_argument("export_dir", nargs=1, help="export directory with uncompressed files")
+args = parser.parse_args()
+
+vprint = print if not args.quiet else lambda *a, **k: None
+
+# Read NS7 network configurations
+f = open(f'{args.export_dir[0]}/dhcp.json')
+data = json.load(f)
+f.close()
+
+# Initialize UCI pointer
+u = EUci()
+
+local_interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
+
+# Set global options
+for section in u.get("dhcp"):
+    if  u.get("dhcp", section) == "dnsmasq":
+        u.set("dhcp", section, "dhcpleasemax", data['general']["dhcpleasemax"])
+
+# Setup DHCP ranges
+rcounter = len(data['servers'])
+for s in data['servers']:
+    iname = get_interface_name(u, local_interfaces, s["hwaddr"])
+    sname = f'dhcp{rcounter}'
+    vprint(f'Creating DHCP server {sname} on {iname}')
+    u.set("dhcp", sname, "dhcp") # create named record
+    u.set("dhcp", sname, "interface", iname)
+    u.set("dhcp", sname, "leasetime", s["leasetime"])
+    u.set("dhcp", sname, "ignore", s["ignore"])
+    u.set("dhcp", sname, "start", s["start"])
+    u.set("dhcp", sname, "limit", s["limit"])
+    u.set("dhcp", sname, "dhcp_option", s["dhcp_option"])
+    if s["domain"]:
+        u.set("dhcp", sname, "domain", s["domain"])
+    rcounter = rcounter - 1
+
+# Create static leases
+for r in data['reservations']:
+    rname = sanitize(r["name"])
+    vprint(f'Creating static lease {rname}')
+    u.set("dhcp", rname, "host") # create named record
+    #u.set("network", aname, "device", u.get("network", sanitize(a["device"]), "device"))
+    u.set("dhcp", rname, "name", rname)
+    u.set("dhcp", rname, "mac", r['mac'])
+    u.set("dhcp", rname, "ip", r['ip'])
+    u.set("dhcp", rname, "dns", 1)
+
+# Save configuration
+u.commit("dhcp")

--- a/packages/ns-migration/files/scripts/dhcp
+++ b/packages/ns-migration/files/scripts/dhcp
@@ -31,8 +31,7 @@ for r in data['reservations']:
     rname = fwutils.sanitize(r["name"])
     fwutils.vprint(f'Creating static lease {rname}')
     u.set("dhcp", rname, "host") # create named record
-    #u.set("network", aname, "device", u.get("network", fwutils.sanitize(a["device"]), "device"))
-    u.set("dhcp", rname, "name", rname)
+    u.set("dhcp", rname, "name", r["name"])
     u.set("dhcp", rname, "mac", r['mac'])
     u.set("dhcp", rname, "ip", r['ip'])
     u.set("dhcp", rname, "dns", 1)

--- a/packages/ns-migration/files/scripts/dhcp
+++ b/packages/ns-migration/files/scripts/dhcp
@@ -8,7 +8,7 @@
 from nextsec import firewall, utils
 import nsmigration
 
-(u, data) = nsmigration.init("dhcp.json")
+(u, data, nmap) = nsmigration.init("dhcp.json")
 
 # Set global options
 for section in u.get("dhcp"):
@@ -20,7 +20,7 @@ for section in u.get("dhcp"):
 # Setup DHCP ranges
 rcounter = len(data['servers'])
 for s in data['servers']:
-    iname = firewall.get_interface_name(u, s["hwaddr"])
+    iname = firewall.get_interface_name(u, nsmigration.remap(s["hwaddr"], nmap))
     sname = utils.get_id(f'dhcp{rcounter}')
     nsmigration.vprint(f'Creating DHCP server {sname} on {iname}')
     u.set("dhcp", sname, "dhcp") # create named record

--- a/packages/ns-migration/files/scripts/dhcp
+++ b/packages/ns-migration/files/scripts/dhcp
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-from nextsec import firewall
-from nextsec import utils
+from nextsec import firewall, utils
 import nsmigration
 
 (u, data) = nsmigration.init("dhcp.json")
@@ -15,12 +14,14 @@ import nsmigration
 for section in u.get("dhcp"):
     if  u.get("dhcp", section) == "dnsmasq":
         u.set("dhcp", section, "dhcpleasemax", data['general']["dhcpleasemax"])
+        # add ns_ prefix to the section
+        u.rename("dhcp", section, utils.get_id("dnsmasq"))
 
 # Setup DHCP ranges
 rcounter = len(data['servers'])
 for s in data['servers']:
     iname = firewall.get_interface_name(u, s["hwaddr"])
-    sname = f'dhcp{rcounter}'
+    sname = utils.get_id(f'dhcp{rcounter}')
     nsmigration.vprint(f'Creating DHCP server {sname} on {iname}')
     u.set("dhcp", sname, "dhcp") # create named record
     u.set("dhcp", sname, "interface", iname)

--- a/packages/ns-migration/files/scripts/dhcp
+++ b/packages/ns-migration/files/scripts/dhcp
@@ -5,9 +5,11 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+from nextsec import firewall
+from nextsec import utils
+import nsmigration
 
-(u, data) = fwutils.init("dhcp.json")
+(u, data) = nsmigration.init("dhcp.json")
 
 # Set global options
 for section in u.get("dhcp"):
@@ -17,9 +19,9 @@ for section in u.get("dhcp"):
 # Setup DHCP ranges
 rcounter = len(data['servers'])
 for s in data['servers']:
-    iname = fwutils.get_interface_name(u, s["hwaddr"])
+    iname = firewall.get_interface_name(u, s["hwaddr"])
     sname = f'dhcp{rcounter}'
-    fwutils.vprint(f'Creating DHCP server {sname} on {iname}')
+    nsmigration.vprint(f'Creating DHCP server {sname} on {iname}')
     u.set("dhcp", sname, "dhcp") # create named record
     u.set("dhcp", sname, "interface", iname)
     u.set("dhcp", sname, "leasetime", s["leasetime"])
@@ -45,11 +47,11 @@ def already_reserved(ip):
 for r in data['reservations']:
     # DHCP will refuse to start if there are multiple static leases with the same IP address
     if already_reserved(r['ip']):
-        fwutils.vprint(f'Skipping duplicate lease {r["name"]}')
+        nsmigration.vprint(f'Skipping duplicate lease {r["name"]}')
         continue
 
-    rname = fwutils.sanitize(r["name"])
-    fwutils.vprint(f'Creating static lease {rname}')
+    rname = utils.get_id(r["name"])
+    nsmigration.vprint(f'Creating static lease {rname}')
     u.set("dhcp", rname, "host") # create named record
     u.set("dhcp", rname, "name", r["name"])
     u.set("dhcp", rname, "mac", r['mac'])

--- a/packages/ns-migration/files/scripts/dns
+++ b/packages/ns-migration/files/scripts/dns
@@ -1,52 +1,14 @@
 #!/usr/bin/python3
 
-import sys
-import json
-import argparse
-import subprocess
-from glob import glob
-from euci import EUci
+import fwutils
 
-def get_interface_name(euci, interfaces, hwaddr):
-    name = ""
-    for interface in interfaces:
-        if interface["address"] == hwaddr:
-            name = interface["ifname"]
-        if name:
-            break
-
-    for section in u.get("network"):
-        if  u.get("network", section) == "interface" and (u.get("network", section, "device") == name):
-            return section
-
-    return None
-
-def sanitize(name):
-    return name.translate({ord(i): '_' for i in ' -.'})
-
-# Parse command line arguments
-parser = argparse.ArgumentParser(description="Import network and basic firewall configuration")
-parser.add_argument("--quiet", "-q", action="store_true", help="don't print executed actions to stdout")
-parser.add_argument("export_dir", nargs=1, help="export directory with uncompressed files")
-args = parser.parse_args()
-
-vprint = print if not args.quiet else lambda *a, **k: None
-
-# Read NS7 network configurations
-f = open(f'{args.export_dir[0]}/dns.json')
-data = json.load(f)
-f.close()
-
-# Initialize UCI pointer
-u = EUci()
-
-local_interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
+(u, data) = fwutils.init("dns.json")
 
 # Setup hostname
 fqdn = f'{data["general"]["hostname"]}.{data["general"]["domain"]}'
 for section in u.get("system"):
     if  u.get("system", section) == "system":
-        vprint(f"Setting FQDN {fqdn}")
+        fwutils.vprint(f"Setting FQDN {fqdn}")
         u.set("system", section, "hostname", fqdn)
         del data["general"]["hostname"] # avoid to set an unsupported option in the next loop
 
@@ -54,18 +16,18 @@ for section in u.get("system"):
 for section in u.get("dhcp"):
     if  u.get("dhcp", section) == "dnsmasq":
         for o in data['general']:
-            vprint(f"Setting DNS option {o}")
+            fwutils.vprint(f"Setting DNS option {o}")
             u.set("dhcp", section, o, data['general'][o])
 
-        vprint(f"Setting DNS forwardings")
+        fwutils.vprint(f"Setting DNS forwardings")
         u.set("dhcp", section, "server", data["forwardings"])
         u.set("dhcp", section, "local", f'/{data["general"]["domain"]}/')
 
 
 # Create hosts entries
 for host in data["hosts"]:
-    hname = sanitize(host["name"])
-    vprint(f'Creating host {hname}')
+    hname = fwutils.sanitize(host["name"])
+    fwutils.vprint(f'Creating host {hname}')
     u.set("dhcp", hname, "domain") # create named record
     for o in host:
         u.set("dhcp", hname, o, host[o])

--- a/packages/ns-migration/files/scripts/dns
+++ b/packages/ns-migration/files/scripts/dns
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+
+import sys
+import json
+import argparse
+import subprocess
+from glob import glob
+from euci import EUci
+
+def get_interface_name(euci, interfaces, hwaddr):
+    name = ""
+    for interface in interfaces:
+        if interface["address"] == hwaddr:
+            name = interface["ifname"]
+        if name:
+            break
+
+    for section in u.get("network"):
+        if  u.get("network", section) == "interface" and (u.get("network", section, "device") == name):
+            return section
+
+    return None
+
+def sanitize(name):
+    return name.translate({ord(i): '_' for i in ' -.'})
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Import network and basic firewall configuration")
+parser.add_argument("--quiet", "-q", action="store_true", help="don't print executed actions to stdout")
+parser.add_argument("export_dir", nargs=1, help="export directory with uncompressed files")
+args = parser.parse_args()
+
+vprint = print if not args.quiet else lambda *a, **k: None
+
+# Read NS7 network configurations
+f = open(f'{args.export_dir[0]}/dns.json')
+data = json.load(f)
+f.close()
+
+# Initialize UCI pointer
+u = EUci()
+
+local_interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
+
+# Setup hostname
+fqdn = f'{data["general"]["hostname"]}.{data["general"]["domain"]}'
+for section in u.get("system"):
+    if  u.get("system", section) == "system":
+        vprint(f"Setting FQDN {fqdn}")
+        u.set("system", section, "hostname", fqdn)
+        del data["general"]["hostname"] # avoid to set an unsupported option in the next loop
+
+# Set global options
+for section in u.get("dhcp"):
+    if  u.get("dhcp", section) == "dnsmasq":
+        for o in data['general']:
+            vprint(f"Setting DNS option {o}")
+            u.set("dhcp", section, o, data['general'][o])
+
+        vprint(f"Setting DNS forwardings")
+        u.set("dhcp", section, "server", data["forwardings"])
+        u.set("dhcp", section, "local", f'/{data["general"]["domain"]}/')
+
+
+# Create hosts entries
+for host in data["hosts"]:
+    hname = sanitize(host["name"])
+    vprint(f'Creating host {hname}')
+    u.set("dhcp", hname, "domain") # create named record
+    for o in host:
+        u.set("dhcp", hname, o, host[o])
+
+# Save configuration
+u.commit("dhcp")
+u.commit("system")

--- a/packages/ns-migration/files/scripts/dns
+++ b/packages/ns-migration/files/scripts/dns
@@ -1,5 +1,10 @@
 #!/usr/bin/python3
 
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
 import fwutils
 
 (u, data) = fwutils.init("dns.json")

--- a/packages/ns-migration/files/scripts/dns
+++ b/packages/ns-migration/files/scripts/dns
@@ -12,9 +12,11 @@ for section in u.get("system"):
         u.set("system", section, "hostname", fqdn)
         del data["general"]["hostname"] # avoid to set an unsupported option in the next loop
 
+dnsmasq_section = ''
 # Set global options
 for section in u.get("dhcp"):
     if  u.get("dhcp", section) == "dnsmasq":
+        dnsmasq_section = section # for later use
         for o in data['general']:
             fwutils.vprint(f"Setting DNS option {o}")
             u.set("dhcp", section, o, data['general'][o])
@@ -31,6 +33,14 @@ for host in data["hosts"]:
     u.set("dhcp", hname, "domain") # create named record
     for o in host:
         u.set("dhcp", hname, o, host[o])
+
+# Create wildcard hosts
+addresses = []
+for address in data["addresses"]:
+    aname = fwutils.sanitize(address["name"])
+    fwutils.vprint(f'Creating wildcard record {aname}')
+    addresses.append(f'/{address["name"]}/{address["ip"]}')
+u.set("dhcp", dnsmasq_section, "address", addresses)
 
 # Save configuration
 u.commit("dhcp")

--- a/packages/ns-migration/files/scripts/dns
+++ b/packages/ns-migration/files/scripts/dns
@@ -5,15 +5,16 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+from nextsec import utils
+import nsmigration
 
-(u, data) = fwutils.init("dns.json")
+(u, data) = nsmigration.init("dns.json")
 
 # Setup hostname
 fqdn = f'{data["general"]["hostname"]}.{data["general"]["domain"]}'
 for section in u.get("system"):
     if  u.get("system", section) == "system":
-        fwutils.vprint(f"Setting FQDN {fqdn}")
+        nsmigration.vprint(f"Setting FQDN {fqdn}")
         u.set("system", section, "hostname", fqdn)
         del data["general"]["hostname"] # avoid to set an unsupported option in the next loop
 
@@ -23,18 +24,18 @@ for section in u.get("dhcp"):
     if  u.get("dhcp", section) == "dnsmasq":
         dnsmasq_section = section # for later use
         for o in data['general']:
-            fwutils.vprint(f"Setting DNS option {o}")
+            nsmigration.vprint(f"Setting DNS option {o}")
             u.set("dhcp", section, o, data['general'][o])
 
-        fwutils.vprint(f"Setting DNS forwardings")
+        nsmigration.vprint(f"Setting DNS forwardings")
         u.set("dhcp", section, "server", data["forwardings"])
         u.set("dhcp", section, "local", f'/{data["general"]["domain"]}/')
 
 
 # Create hosts entries
 for host in data["hosts"]:
-    hname = fwutils.sanitize(host["name"])
-    fwutils.vprint(f'Creating host {hname}')
+    hname = utils.sanitize(host["name"])
+    nsmigration.vprint(f'Creating host {hname}')
     u.set("dhcp", hname, "domain") # create named record
     for o in host:
         u.set("dhcp", hname, o, host[o])
@@ -42,8 +43,8 @@ for host in data["hosts"]:
 # Create wildcard hosts
 addresses = []
 for address in data["addresses"]:
-    aname = fwutils.sanitize(address["name"])
-    fwutils.vprint(f'Creating wildcard record {aname}')
+    aname = utils.sanitize(address["name"])
+    nsmigration.vprint(f'Creating wildcard record {aname}')
     addresses.append(f'/{address["name"]}/{address["ip"]}')
 u.set("dhcp", dnsmasq_section, "address", addresses)
 

--- a/packages/ns-migration/files/scripts/dns
+++ b/packages/ns-migration/files/scripts/dns
@@ -34,7 +34,7 @@ for section in u.get("dhcp"):
 
 # Create hosts entries
 for host in data["hosts"]:
-    hname = utils.sanitize(host["name"])
+    hname = utils.get_id(host["name"])
     nsmigration.vprint(f'Creating host {hname}')
     u.set("dhcp", hname, "domain") # create named record
     for o in host:
@@ -43,7 +43,7 @@ for host in data["hosts"]:
 # Create wildcard hosts
 addresses = []
 for address in data["addresses"]:
-    aname = utils.sanitize(address["name"])
+    aname = utils.get_id(address["name"])
     nsmigration.vprint(f'Creating wildcard record {aname}')
     addresses.append(f'/{address["name"]}/{address["ip"]}')
 u.set("dhcp", dnsmasq_section, "address", addresses)

--- a/packages/ns-migration/files/scripts/dns
+++ b/packages/ns-migration/files/scripts/dns
@@ -8,7 +8,7 @@
 from nextsec import utils
 import nsmigration
 
-(u, data) = nsmigration.init("dns.json")
+(u, data, nmap) = nsmigration.init("dns.json")
 
 # Setup hostname
 fqdn = f'{data["general"]["hostname"]}.{data["general"]["domain"]}'

--- a/packages/ns-migration/files/scripts/fwutils.py
+++ b/packages/ns-migration/files/scripts/fwutils.py
@@ -1,5 +1,10 @@
 #!/usr/bin/python3
 
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
 import re
 import sys
 import json

--- a/packages/ns-migration/files/scripts/fwutils.py
+++ b/packages/ns-migration/files/scripts/fwutils.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+import re
+import sys
+import json
+import argparse
+import subprocess
+from glob import glob
+from euci import EUci
+
+# Retrieve the physical device name given the MAC address
+def get_device_name(hwaddr):
+    interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
+    for interface in interfaces:
+        if interface["address"] == hwaddr:
+            return interface["ifname"]
+
+    return None
+
+# Retrieve the logical UCI interface name given the MAC address
+def get_interface_name(uci, hwaddr):
+    name = get_device_name(hwaddr)
+    for section in uci.get("network"):
+        if  uci.get("network", section) == "interface" and (uci.get("network", section, "device") == name):
+            return section
+
+    return None
+
+# Replace illegal chars with _
+# UCI identifiers and config file names may contain only the characters a-z, 0-9 and _
+def sanitize(name):
+    name = re.sub(r'[^\x00-\x7F]+','_', name)
+    name = re.sub('[^0-9a-zA-Z]', '_', name)
+    return name
+
+# Global print function
+vprint = print
+
+#
+# Parse command line arguments, initialize UCI and read export file
+# Return a tuple of:
+#  - euci pointer
+#  - hash of parsed export data
+#
+def init(data_file):
+    global vprint
+
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Import network and basic firewall configuration")
+    parser.add_argument("--quiet", "-q", action="store_true", help="don't print executed actions to stdout")
+    parser.add_argument("export_dir", nargs=1, help="export directory with uncompressed files")
+    args = parser.parse_args()
+
+    # Define print as an empty function if 'quiet' options is enabled
+    vprint = print if not args.quiet else lambda *a, **k: None
+
+    # Initialize UCI pointer
+    u = EUci()
+
+    # Read NS7 network configurations
+    f = open(f'{args.export_dir[0]}/{data_file}')
+    data = json.load(f)
+    f.close()
+
+    return (u, data)

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -79,6 +79,20 @@ for i in data['interfaces']:
     if i["gateway"]:
         u.set("network", iname, "gateway", i["gateway"])
 
+# Create aliases
+acount = len(data['aliases'])
+for a in data['aliases']:
+    aname = sanitize(a["device"])+str(acount)
+    vprint(f'Creating alias {aname}')
+    u.set("network", aname, "interface") # create named record
+    u.set("network", aname, "device", f'@{sanitize(a["device"])}')
+    u.set("network", aname, "ipaddr", a["ipaddr"])
+    u.set("network", aname, "netmask", a["netmask"])
+    u.set("network", aname, "proto", a["proto"])
+    if a["gateway"]:
+        u.set("network", aname, "gateway", a["gateway"])
+    acount = acount - 1
+
 # Create firewall zones
 for z in data['zones']:
     vprint(f'Creating zone {z["name"]}')
@@ -110,7 +124,7 @@ for s in data['snats']:
     u.set("firewall", sname, "proto", [s["proto"]])
     u.set("firewall", sname, "snat_ip", s["snat_ip"])
     u.set("firewall", sname, "src_ip", s["src_ip"])
-    u.set("firewall", sname, "src", sanitize(s["src"]))
+    u.set("firewall", sname, "src", "wan")
 
 # Save configuration
 u.commit("network")

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -13,6 +13,9 @@ def get_interface_name(interfaces, hwaddr):
 
     return None
 
+def sanitize(name):
+    return name.translate({ord(i): '_' for i in ' -'})
+
 if not sys.argv[1]:
     print(f"Usage: {sys.argv[0]} <export_directory>")
     sys.exit(1)
@@ -22,27 +25,73 @@ data = json.load(f)
 f.close()
 
 u = EUci()
-local_interfaces = json.loads(subprocess.run("ip --json address show", check=True, capture_output=True))
 
-for v in data['vlans']:
-    u.set("network", "", "type", v["type"])
-    u.set("network", "", "type", v["id"])
-
-# Cleanup default configuration
+# Cleanup default network configuration
 for section in u.get("network"):
     s_type = u.get("network", section)
     if s_type == "interface" and (section == "wan" or section == "wan6" or section == "lan"):
-        print(f"Deleting {section}")
+        print(f"Deleting interface {section}")
         u.delete("network", section)
     if s_type == "device":
         ts = u.get_all("network", section)
         if ts['name'] == 'br-lan':
-            print(f"Deleting {section}")
+            print(f"Deleting interface {section}")
             u.delete("network", section)
 
+# Cleanup default firewall zones
+for section in u.get("firewall"):
+    s_type = u.get("firewall", section)
+    if s_type == "zone":
+        z_name = u.get("firewall", section, "name")
+        if z_name == "wan" or z_name == "wan6" or z_name == "lan":
+            print(f"Deleting zone {section}: {u.get_all('firewall', section)}")
+            u.delete("network", section)
+
+local_interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
+
+# Create vlan devices
+for v in data['vlans']:
+    iname = get_interface_name(local_interfaces, v["hwaddr"])
+    vname = f'vlan{v["vid"]}'
+    u.set("network", vname, "device") # create named record
+    u.set("network", vname, "type", v["type"])
+    u.set("network", vname, "vid", v["vid"])
+    u.set("network", vname, "ifname", iname)
+    u.set("network", vname, "name", f'{iname}.{v["vid"]}')
+
+# Create interfaces
+for i in data['interfaces']:
+    iname = sanitize(i["interface"])
+    print(f'Creating interface {iname}')
+    u.set("network", iname, "interface") # create named record
+    u.set("network", iname, "proto", i["proto"])
+    u.set("network", iname, "device", get_interface_name(local_interfaces, i["hwaddr"]))
+    if i["ipaddr"]:
+        u.set("network", iname, "ipaddr", i["ipaddr"])
+        u.set("network", iname, "netmask", i["netmask"])
+    if i["gateway"]:
+        u.set("network", iname, "gateway", i["gateway"])
+
+# Create firewall zones
+for z in data['zones']:
+    print(f'Creating zone {z["name"]}')
+    u.set("firewall", z["name"], "zone") # create named record
+    u.set("firewall", z["name"], "name", z["name"])
+    u.set("firewall", z["name"], "output", z["output"])
+    u.set("firewall", z["name"], "input", z["input"])
+    u.set("firewall", z["name"], "forward", z["forward"])
+    u.set("firewall", z["name"], "network", [sanitize(n) for n in z["network"]])
+    if z["name"].startswith("wan"): # setup masquerading for wans
+        u.set("firewall", z["name"], "masq", '1')
+        u.set("firewall", z["name"], "mtu_fix", '1')
+
+# Create firewall forwardings
+for f in data['forwardings']:
+    fname = f'{f["src"]}2{f["dest"]}'
+    print(f'Creating forwarding {fname}')
+    u.set("firewall", fname, "forwarding") # create named record
+    u.set("firewall", fname, "src", f["src"])
+    u.set("firewall", fname, "dest", f["dest"])
+
 u.commit("network")
-
-
-
-
-print(data)
+u.commit("firewall")

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+
+import sys
+import json
+import subprocess
+from glob import glob
+from euci import EUci
+
+def get_interface_name(interfaces, hwaddr):
+    for interface in interfaces:
+        if interface["address"] == hwaddr:
+            return interface["ifname"]
+
+    return None
+
+if not sys.argv[1]:
+    print(f"Usage: {sys.argv[0]} <export_directory>")
+    sys.exit(1)
+
+f = open(f'{sys.argv[1]}/network.json')
+data = json.load(f)
+f.close()
+
+u = EUci()
+local_interfaces = json.loads(subprocess.run("ip --json address show", check=True, capture_output=True))
+
+for v in data['vlans']:
+    u.set("network", "", "type", v["type"])
+    u.set("network", "", "type", v["id"])
+
+# Cleanup default configuration
+for section in u.get("network"):
+    s_type = u.get("network", section)
+    if s_type == "interface" and (section == "wan" or section == "wan6" or section == "lan"):
+        print(f"Deleting {section}")
+        u.delete("network", section)
+    if s_type == "device":
+        ts = u.get_all("network", section)
+        if ts['name'] == 'br-lan':
+            print(f"Deleting {section}")
+            u.delete("network", section)
+
+u.commit("network")
+
+
+
+
+print(data)

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -1,5 +1,10 @@
 #!/usr/bin/python3
 
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
 import fwutils
 
 (u, data) = fwutils.init("network.json")

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -2,6 +2,7 @@
 
 import sys
 import json
+import argparse
 import subprocess
 from glob import glob
 from euci import EUci
@@ -16,35 +17,41 @@ def get_interface_name(interfaces, hwaddr):
 def sanitize(name):
     return name.translate({ord(i): '_' for i in ' -.'})
 
-if not sys.argv[1]:
-    print(f"Usage: {sys.argv[0]} <export_directory>")
-    sys.exit(1)
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Import network and basic firewall configuration")
+parser.add_argument("--quiet", "-q", action="store_true", help="don't print executed actions to stdout")
+parser.add_argument("export_dir", nargs=1, help="export directory with uncompressed files")
+args = parser.parse_args()
 
-f = open(f'{sys.argv[1]}/network.json')
+vprint = print if not args.quiet else lambda *a, **k: None
+
+# Read NS7 network configurations
+f = open(f'{args.export_dir[0]}/network.json')
 data = json.load(f)
 f.close()
 
+# Initialize UCI pointer
 u = EUci()
 
 # Cleanup default firewall zones
 for section in u.get("firewall"):
     s_type = u.get("firewall", section)
     if s_type == "zone":
-        z_name = u.get("firewall", section, "name")
-        if z_name == "wan" or z_name == "wan6" or z_name == "lan":
-            print(f"Deleting zone {section}: {u.get_all('firewall', section)}")
+        zname = u.get("firewall", section, "name")
+        if zname == "wan" or zname == "wan6" or zname == "lan":
+            vprint(f"Deleting zone {section} ({zname})")
             u.delete("firewall", section)
 
 # Cleanup default network configuration
 for section in u.get("network"):
     s_type = u.get("network", section)
     if s_type == "interface" and (section == "wan" or section == "wan6" or section == "lan"):
-        print(f"Deleting interface {section}")
+        vprint(f"Deleting interface {section}")
         u.delete("network", section)
     if s_type == "device":
         ts = u.get_all("network", section)
         if ts['name'] == 'br-lan':
-            print(f"Deleting interface {section}")
+            vprint(f"Deleting interface {section}")
             u.delete("network", section)
 
 local_interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
@@ -62,7 +69,7 @@ for v in data['vlans']:
 # Create interfaces
 for i in data['interfaces']:
     iname = sanitize(i["interface"])
-    print(f'Creating interface {iname}')
+    vprint(f'Creating interface {iname}')
     u.set("network", iname, "interface") # create named record
     u.set("network", iname, "proto", i["proto"])
     u.set("network", iname, "device", get_interface_name(local_interfaces, i["hwaddr"]))
@@ -74,7 +81,7 @@ for i in data['interfaces']:
 
 # Create firewall zones
 for z in data['zones']:
-    print(f'Creating zone {z["name"]}')
+    vprint(f'Creating zone {z["name"]}')
     u.set("firewall", z["name"], "zone") # create named record
     u.set("firewall", z["name"], "name", z["name"])
     u.set("firewall", z["name"], "output", z["output"])
@@ -88,14 +95,14 @@ for z in data['zones']:
 # Create firewall forwardings
 for f in data['forwardings']:
     fname = f'{f["src"]}2{f["dest"]}'
-    print(f'Creating forwarding {fname}')
+    vprint(f'Creating forwarding {fname}')
     u.set("firewall", fname, "forwarding") # create named record
     u.set("firewall", fname, "src", f["src"])
     u.set("firewall", fname, "dest", f["dest"])
 
 # Create snat rules
 for s in data['snats']:
-    print(f'Creating SNAT {s["name"]}')
+    vprint(f'Creating SNAT {s["name"]}')
     sname = sanitize(s["name"])
     u.set("firewall", sname, "nat") # create named record
     u.set("firewall", sname, "name", s["name"])

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -1,37 +1,8 @@
 #!/usr/bin/python3
 
-import sys
-import json
-import argparse
-import subprocess
-from glob import glob
-from euci import EUci
+import fwutils
 
-def get_interface_name(interfaces, hwaddr):
-    for interface in interfaces:
-        if interface["address"] == hwaddr:
-            return interface["ifname"]
-
-    return None
-
-def sanitize(name):
-    return name.translate({ord(i): '_' for i in ' -.'})
-
-# Parse command line arguments
-parser = argparse.ArgumentParser(description="Import network and basic firewall configuration")
-parser.add_argument("--quiet", "-q", action="store_true", help="don't print executed actions to stdout")
-parser.add_argument("export_dir", nargs=1, help="export directory with uncompressed files")
-args = parser.parse_args()
-
-vprint = print if not args.quiet else lambda *a, **k: None
-
-# Read NS7 network configurations
-f = open(f'{args.export_dir[0]}/network.json')
-data = json.load(f)
-f.close()
-
-# Initialize UCI pointer
-u = EUci()
+(u, data) = fwutils.init("network.json")
 
 # Cleanup default firewall zones
 for section in u.get("firewall"):
@@ -39,26 +10,24 @@ for section in u.get("firewall"):
     if s_type == "zone":
         zname = u.get("firewall", section, "name")
         if zname == "wan" or zname == "wan6" or zname == "lan":
-            vprint(f"Deleting zone {section} ({zname})")
+            fwutils.vprint(f"Deleting zone {section} ({zname})")
             u.delete("firewall", section)
 
 # Cleanup default network configuration
 for section in u.get("network"):
     s_type = u.get("network", section)
     if s_type == "interface" and (section == "wan" or section == "wan6" or section == "lan"):
-        vprint(f"Deleting interface {section}")
+        fwutils.vprint(f"Deleting interface {section}")
         u.delete("network", section)
     if s_type == "device":
         ts = u.get_all("network", section)
         if ts['name'] == 'br-lan':
-            vprint(f"Deleting interface {section}")
+            fwutils.vprint(f"Deleting interface {section}")
             u.delete("network", section)
-
-local_interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
 
 # Create vlan devices
 for v in data['vlans']:
-    iname = get_interface_name(local_interfaces, v["hwaddr"])
+    iname = fwutils.get_device_name(v["hwaddr"])
     vname = f'vlan{v["vid"]}'
     u.set("network", vname, "device") # create named record
     u.set("network", vname, "type", v["type"])
@@ -68,11 +37,11 @@ for v in data['vlans']:
 
 # Create interfaces
 for i in data['interfaces']:
-    iname = sanitize(i["interface"])
-    vprint(f'Creating interface {iname}')
+    iname = fwutils.sanitize(i["interface"])
+    fwutils.vprint(f'Creating interface {iname}')
     u.set("network", iname, "interface") # create named record
     u.set("network", iname, "proto", i["proto"])
-    u.set("network", iname, "device", get_interface_name(local_interfaces, i["hwaddr"]))
+    u.set("network", iname, "device", fwutils.get_device_name(i["hwaddr"]))
     if i["ipaddr"]:
         u.set("network", iname, "ipaddr", i["ipaddr"])
         u.set("network", iname, "netmask", i["netmask"])
@@ -82,10 +51,11 @@ for i in data['interfaces']:
 # Create aliases
 acount = len(data['aliases'])
 for a in data['aliases']:
-    aname = sanitize(a["device"])+str(acount)
-    vprint(f'Creating alias {aname}')
+    aname = fwutils.sanitize(a["device"])+str(acount)
+    fwutils.vprint(f'Creating alias {aname}')
     u.set("network", aname, "interface") # create named record
-    u.set("network", aname, "device", f'@{sanitize(a["device"])}')
+    #u.set("network", aname, "device", u.get("network", fwutils.sanitize(a["device"]), "device"))
+    u.set("network", aname, "device", f'@{fwutils.sanitize(a["device"])}')
     u.set("network", aname, "ipaddr", a["ipaddr"])
     u.set("network", aname, "netmask", a["netmask"])
     u.set("network", aname, "proto", a["proto"])
@@ -95,13 +65,13 @@ for a in data['aliases']:
 
 # Create firewall zones
 for z in data['zones']:
-    vprint(f'Creating zone {z["name"]}')
+    fwutils.vprint(f'Creating zone {z["name"]}')
     u.set("firewall", z["name"], "zone") # create named record
     u.set("firewall", z["name"], "name", z["name"])
     u.set("firewall", z["name"], "output", z["output"])
     u.set("firewall", z["name"], "input", z["input"])
     u.set("firewall", z["name"], "forward", z["forward"])
-    u.set("firewall", z["name"], "network", [sanitize(n) for n in z["network"]])
+    u.set("firewall", z["name"], "network", [fwutils.sanitize(n) for n in z["network"]])
     if z["name"].startswith("wan"): # setup masquerading for wans
         u.set("firewall", z["name"], "masq", '1')
         u.set("firewall", z["name"], "mtu_fix", '1')
@@ -109,15 +79,15 @@ for z in data['zones']:
 # Create firewall forwardings
 for f in data['forwardings']:
     fname = f'{f["src"]}2{f["dest"]}'
-    vprint(f'Creating forwarding {fname}')
+    fwutils.vprint(f'Creating forwarding {fname}')
     u.set("firewall", fname, "forwarding") # create named record
     u.set("firewall", fname, "src", f["src"])
     u.set("firewall", fname, "dest", f["dest"])
 
 # Create snat rules
 for s in data['snats']:
-    vprint(f'Creating SNAT {s["name"]}')
-    sname = sanitize(s["name"])
+    fwutils.vprint(f'Creating SNAT {s["name"]}')
+    sname = fwutils.sanitize(s["name"])
     u.set("firewall", sname, "nat") # create named record
     u.set("firewall", sname, "name", s["name"])
     u.set("firewall", sname, "target", s["target"])

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -14,7 +14,7 @@ def get_interface_name(interfaces, hwaddr):
     return None
 
 def sanitize(name):
-    return name.translate({ord(i): '_' for i in ' -'})
+    return name.translate({ord(i): '_' for i in ' -.'})
 
 if not sys.argv[1]:
     print(f"Usage: {sys.argv[0]} <export_directory>")
@@ -26,6 +26,15 @@ f.close()
 
 u = EUci()
 
+# Cleanup default firewall zones
+for section in u.get("firewall"):
+    s_type = u.get("firewall", section)
+    if s_type == "zone":
+        z_name = u.get("firewall", section, "name")
+        if z_name == "wan" or z_name == "wan6" or z_name == "lan":
+            print(f"Deleting zone {section}: {u.get_all('firewall', section)}")
+            u.delete("firewall", section)
+
 # Cleanup default network configuration
 for section in u.get("network"):
     s_type = u.get("network", section)
@@ -36,15 +45,6 @@ for section in u.get("network"):
         ts = u.get_all("network", section)
         if ts['name'] == 'br-lan':
             print(f"Deleting interface {section}")
-            u.delete("network", section)
-
-# Cleanup default firewall zones
-for section in u.get("firewall"):
-    s_type = u.get("firewall", section)
-    if s_type == "zone":
-        z_name = u.get("firewall", section, "name")
-        if z_name == "wan" or z_name == "wan6" or z_name == "lan":
-            print(f"Deleting zone {section}: {u.get_all('firewall', section)}")
             u.delete("network", section)
 
 local_interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
@@ -93,5 +93,18 @@ for f in data['forwardings']:
     u.set("firewall", fname, "src", f["src"])
     u.set("firewall", fname, "dest", f["dest"])
 
+# Create snat rules
+for s in data['snats']:
+    print(f'Creating SNAT {s["name"]}')
+    sname = sanitize(s["name"])
+    u.set("firewall", sname, "nat") # create named record
+    u.set("firewall", sname, "name", s["name"])
+    u.set("firewall", sname, "target", s["target"])
+    u.set("firewall", sname, "proto", [s["proto"]])
+    u.set("firewall", sname, "snat_ip", s["snat_ip"])
+    u.set("firewall", sname, "src_ip", s["src_ip"])
+    u.set("firewall", sname, "src", sanitize(s["src"]))
+
+# Save configuration
 u.commit("network")
 u.commit("firewall")

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -5,9 +5,10 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+import nsmigration
+from nextsec import firewall, utils
 
-(u, data) = fwutils.init("network.json")
+(u, data) = nsmigration.init("network.json")
 
 # Cleanup default firewall zones
 for section in u.get("firewall"):
@@ -15,24 +16,24 @@ for section in u.get("firewall"):
     if s_type == "zone":
         zname = u.get("firewall", section, "name")
         if zname == "wan" or zname == "wan6" or zname == "lan":
-            fwutils.vprint(f"Deleting zone {section} ({zname})")
+            nsmigration.vprint(f"Deleting zone {section} ({zname})")
             u.delete("firewall", section)
 
 # Cleanup default network configuration
 for section in u.get("network"):
     s_type = u.get("network", section)
     if s_type == "interface" and (section == "wan" or section == "wan6" or section == "lan"):
-        fwutils.vprint(f"Deleting interface {section}")
+        nsmigration.vprint(f"Deleting interface {section}")
         u.delete("network", section)
     if s_type == "device":
         ts = u.get_all("network", section)
         if ts['name'] == 'br-lan':
-            fwutils.vprint(f"Deleting interface {section}")
+            nsmigration.vprint(f"Deleting interface {section}")
             u.delete("network", section)
 
 # Create vlan devices
 for v in data['vlans']:
-    iname = fwutils.get_device_name(v["hwaddr"])
+    iname = firewall.get_device_name(v["hwaddr"])
     vname = f'vlan{v["vid"]}'
     u.set("network", vname, "device") # create named record
     u.set("network", vname, "type", v["type"])
@@ -42,11 +43,11 @@ for v in data['vlans']:
 
 # Create interfaces
 for i in data['interfaces']:
-    iname = fwutils.sanitize(i["interface"])
-    fwutils.vprint(f'Creating interface {iname}')
+    iname = utils.sanitize(i["interface"])
+    nsmigration.vprint(f'Creating interface {iname}')
     u.set("network", iname, "interface") # create named record
     u.set("network", iname, "proto", i["proto"])
-    u.set("network", iname, "device", fwutils.get_device_name(i["hwaddr"]))
+    u.set("network", iname, "device", firewall.get_device_name(i["hwaddr"]))
     if i["ipaddr"]:
         u.set("network", iname, "ipaddr", i["ipaddr"])
         u.set("network", iname, "netmask", i["netmask"])
@@ -56,11 +57,10 @@ for i in data['interfaces']:
 # Create aliases
 acount = len(data['aliases'])
 for a in data['aliases']:
-    aname = fwutils.sanitize(a["device"])+str(acount)
-    fwutils.vprint(f'Creating alias {aname}')
+    aname = utils.sanitize(a["device"])+str(acount)
+    nsmigration.vprint(f'Creating alias {aname}')
     u.set("network", aname, "interface") # create named record
-    #u.set("network", aname, "device", u.get("network", fwutils.sanitize(a["device"]), "device"))
-    u.set("network", aname, "device", f'@{fwutils.sanitize(a["device"])}')
+    u.set("network", aname, "device", f'@{utils.sanitize(a["device"])}')
     u.set("network", aname, "ipaddr", a["ipaddr"])
     u.set("network", aname, "netmask", a["netmask"])
     u.set("network", aname, "proto", a["proto"])
@@ -70,13 +70,13 @@ for a in data['aliases']:
 
 # Create firewall zones
 for z in data['zones']:
-    fwutils.vprint(f'Creating zone {z["name"]}')
+    nsmigration.vprint(f'Creating zone {z["name"]}')
     u.set("firewall", z["name"], "zone") # create named record
     u.set("firewall", z["name"], "name", z["name"])
     u.set("firewall", z["name"], "output", z["output"])
     u.set("firewall", z["name"], "input", z["input"])
     u.set("firewall", z["name"], "forward", z["forward"])
-    u.set("firewall", z["name"], "network", [fwutils.sanitize(n) for n in z["network"]])
+    u.set("firewall", z["name"], "network", [utils.sanitize(n) for n in z["network"]])
     if z["name"].startswith("wan"): # setup masquerading for wans
         u.set("firewall", z["name"], "masq", '1')
         u.set("firewall", z["name"], "mtu_fix", '1')
@@ -84,15 +84,15 @@ for z in data['zones']:
 # Create firewall forwardings
 for f in data['forwardings']:
     fname = f'{f["src"]}2{f["dest"]}'
-    fwutils.vprint(f'Creating forwarding {fname}')
+    nsmigration.vprint(f'Creating forwarding {fname}')
     u.set("firewall", fname, "forwarding") # create named record
     u.set("firewall", fname, "src", f["src"])
     u.set("firewall", fname, "dest", f["dest"])
 
 # Create snat rules
 for s in data['snats']:
-    fwutils.vprint(f'Creating SNAT {s["name"]}')
-    sname = fwutils.sanitize(s["name"])
+    nsmigration.vprint(f'Creating SNAT {s["name"]}')
+    sname = utils.sanitize(s["name"])
     u.set("firewall", sname, "nat") # create named record
     u.set("firewall", sname, "name", s["name"])
     u.set("firewall", sname, "target", s["target"])

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -34,7 +34,7 @@ for section in u.get("network"):
 # Create vlan devices
 for v in data['vlans']:
     iname = firewall.get_device_name(v["hwaddr"])
-    vname = f'vlan{v["vid"]}'
+    vname = utils.sanitize(f'vlan{v["vid"]}')
     u.set("network", vname, "device") # create named record
     u.set("network", vname, "type", v["type"])
     u.set("network", vname, "vid", v["vid"])
@@ -71,19 +71,20 @@ for a in data['aliases']:
 # Create firewall zones
 for z in data['zones']:
     nsmigration.vprint(f'Creating zone {z["name"]}')
-    u.set("firewall", z["name"], "zone") # create named record
-    u.set("firewall", z["name"], "name", z["name"])
-    u.set("firewall", z["name"], "output", z["output"])
-    u.set("firewall", z["name"], "input", z["input"])
-    u.set("firewall", z["name"], "forward", z["forward"])
-    u.set("firewall", z["name"], "network", [utils.sanitize(n) for n in z["network"]])
+    zname = utils.get_id(z["name"])
+    u.set("firewall", zname, "zone") # create named record
+    u.set("firewall", zname, "name", z["name"])
+    u.set("firewall", zname, "output", z["output"])
+    u.set("firewall", zname, "input", z["input"])
+    u.set("firewall", zname, "forward", z["forward"])
+    u.set("firewall", zname, "network", [utils.sanitize(n) for n in z["network"]])
     if z["name"].startswith("wan"): # setup masquerading for wans
-        u.set("firewall", z["name"], "masq", '1')
-        u.set("firewall", z["name"], "mtu_fix", '1')
+        u.set("firewall", zname, "masq", '1')
+        u.set("firewall", zname, "mtu_fix", '1')
 
 # Create firewall forwardings
 for f in data['forwardings']:
-    fname = f'{f["src"]}2{f["dest"]}'
+    fname = utils.get_id(f'{f["src"]}2{f["dest"]}')
     nsmigration.vprint(f'Creating forwarding {fname}')
     u.set("firewall", fname, "forwarding") # create named record
     u.set("firewall", fname, "src", f["src"])
@@ -92,7 +93,7 @@ for f in data['forwardings']:
 # Create snat rules
 for s in data['snats']:
     nsmigration.vprint(f'Creating SNAT {s["name"]}')
-    sname = utils.sanitize(s["name"])
+    sname = utils.get_id(s["name"])
     u.set("firewall", sname, "nat") # create named record
     u.set("firewall", sname, "name", s["name"])
     u.set("firewall", sname, "target", s["target"])

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -8,7 +8,7 @@
 import nsmigration
 from nextsec import firewall, utils
 
-(u, data) = nsmigration.init("network.json")
+(u, data, nmap) = nsmigration.init("network.json")
 
 # Cleanup default firewall zones
 for section in u.get("firewall"):
@@ -33,8 +33,9 @@ for section in u.get("network"):
 
 # Create vlan devices
 for v in data['vlans']:
-    iname = firewall.get_device_name(v["hwaddr"])
+    iname = firewall.get_device_name(nsmigration.remap(v["hwaddr"], nmap))
     vname = utils.sanitize(f'vlan{v["vid"]}')
+    nsmigration.vprint(f"Creating vlan {iname}")
     u.set("network", vname, "device") # create named record
     u.set("network", vname, "type", v["type"])
     u.set("network", vname, "vid", v["vid"])
@@ -47,7 +48,7 @@ for i in data['interfaces']:
     nsmigration.vprint(f'Creating interface {iname}')
     u.set("network", iname, "interface") # create named record
     u.set("network", iname, "proto", i["proto"])
-    u.set("network", iname, "device", firewall.get_device_name(i["hwaddr"]))
+    u.set("network", iname, "device", firewall.get_device_name(nsmigration.remap(v['hwaddr'], nmap)))
     if i["ipaddr"]:
         u.set("network", iname, "ipaddr", i["ipaddr"])
         u.set("network", iname, "netmask", i["netmask"])

--- a/packages/ns-migration/files/scripts/nsmigration.py
+++ b/packages/ns-migration/files/scripts/nsmigration.py
@@ -5,38 +5,9 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import re
-import sys
 import json
 import argparse
-import subprocess
-from glob import glob
 from euci import EUci
-
-# Retrieve the physical device name given the MAC address
-def get_device_name(hwaddr):
-    interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
-    for interface in interfaces:
-        if interface["address"] == hwaddr:
-            return interface["ifname"]
-
-    return None
-
-# Retrieve the logical UCI interface name given the MAC address
-def get_interface_name(uci, hwaddr):
-    name = get_device_name(hwaddr)
-    for section in uci.get("network"):
-        if  uci.get("network", section) == "interface" and (uci.get("network", section, "device") == name):
-            return section
-
-    return None
-
-# Replace illegal chars with _
-# UCI identifiers and config file names may contain only the characters a-z, 0-9 and _
-def sanitize(name):
-    name = re.sub(r'[^\x00-\x7F]+','_', name)
-    name = re.sub('[^0-9a-zA-Z]', '_', name)
-    return name
 
 # Global print function
 vprint = print

--- a/packages/ns-migration/files/scripts/nsmigration.py
+++ b/packages/ns-migration/files/scripts/nsmigration.py
@@ -17,6 +17,7 @@ vprint = print
 # Return a tuple of:
 #  - euci pointer
 #  - hash of parsed export data
+#  - hash of network to be remapped, like { oldmac => newmac }
 #
 def init(data_file):
     global vprint
@@ -24,6 +25,7 @@ def init(data_file):
     # Parse command line arguments
     parser = argparse.ArgumentParser(description="Import network and basic firewall configuration")
     parser.add_argument("--quiet", "-q", action="store_true", help="don't print executed actions to stdout")
+    parser.add_argument("--map", "-m", action="append", help="map an old network interface to a new one, syntax example with MAC addresses: 'ae:12:3b:19:0a:2a=0b:64:31:69:ae:8a'")
     parser.add_argument("export_dir", nargs=1, help="export directory with uncompressed files")
     args = parser.parse_args()
 
@@ -38,4 +40,22 @@ def init(data_file):
     data = json.load(f)
     f.close()
 
-    return (u, data)
+    # Prepare network map
+    nmap = dict()
+    for m in args.map:
+        (old, new) = m.split("=")
+        nmap[old]=new
+
+    return (u, data, nmap)
+
+#
+# Remap the given MAC address to a new one
+#
+# If the old MAC must be remapped, return the new MAC address.
+# Otherise, return the old MAC address.
+#
+def remap(hwaddr, network_map):
+    try:
+        return network_map[hwaddr]
+    except:
+        return hwaddr

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -24,7 +24,7 @@ def save_cert(path, data):
     os.chown(path, uid, gid)
 
 
-iname="roadwarrior"
+iname="ns_roadwarrior"
 cert_dir=f"/etc/openvpn/{iname}/pki/"
 subprocess.run(["/usr/sbin/ns-openvpnrw-init-pki", iname], check=True)
 (u, data) = nsmigration.init("openvpn.json")

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -27,7 +27,8 @@ def save_cert(path, data):
 iname="ns_roadwarrior"
 cert_dir=f"/etc/openvpn/{iname}/pki/"
 subprocess.run(["/usr/sbin/ns-openvpnrw-init-pki", iname], check=True)
-(u, data) = nsmigration.init("openvpn.json")
+
+(u, data, nmap) = nsmigration.init("openvpn.json")
 
 # Setup global option
 u.set("openvpn", iname, "openvpn")

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -66,7 +66,8 @@ for user in data["users"]:
     save_cert(os.path.join(cert_dir, f'issued/{sname}.crt'), user['crt'])
 
 # Add interface to LAN
-firewall.add_to_lan(u, data['rw']['options']['dev'])
+ovpn_interface = firewall.add_vpn_interface(u, 'openvpnrw', data['rw']['options']['dev'])
+ovpn_zone = firewall.add_trusted_zone(u, "openvpnrw", [ovpn_interface])
 # Open OpenVPN port
 firewall.add_service(u, 'openvpn_rw', data['rw']['options']['port'], data['rw']['options']['proto'])
 

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -10,6 +10,7 @@ import pwd
 import grp
 import os.path
 import nsmigration
+import subprocess
 from nextsec import firewall, utils
 
 def save_cert(path, data):
@@ -24,9 +25,8 @@ def save_cert(path, data):
 
 
 iname="roadwarrior"
-cert_dir=f"/etc/openvpn/{iname}/certs"
-os.makedirs(cert_dir, exist_ok=True)
-
+cert_dir=f"/etc/openvpn/{iname}/pki/"
+subprocess.run(["/usr/sbin/ns-openvpnrw-init-pki", iname], check=True)
 (u, data) = nsmigration.init("openvpn.json")
 
 # Setup global option
@@ -36,13 +36,20 @@ for option in data['rw']['options']:
     u.set("openvpn", iname, option, data['rw']['options'][option])
 
 # Setup server certificates
-for cert in data['rw']['ca']:
-    save_cert(os.path.join(cert_dir, cert), data['rw']['ca'][cert])
+save_cert(os.path.join(cert_dir, 'ca.crt'), data['rw']['ca']['ca.crt'])
+save_cert(os.path.join(cert_dir, 'index'), data['rw']['ca']['certindex'])
+save_cert(os.path.join(cert_dir, 'index.attr'), data['rw']['ca']['certindex.attr'])
+save_cert(os.path.join(cert_dir, 'crl.pem'), data['rw']['ca']['crl.pem'])
+save_cert(os.path.join(cert_dir, 'serial'), data['rw']['ca']['serial'])
+save_cert(os.path.join(cert_dir, 'issued/server.crt'), data['rw']['ca']['srv.crt'])
+save_cert(os.path.join(cert_dir, 'private/server.key'), data['rw']['ca']['srv.key'])
+save_cert(os.path.join(cert_dir, 'private/ca.key'), data['rw']['ca']['srv.key'])
 u.set("openvpn", iname, 'dh', os.path.join(cert_dir, 'dh.pem'))
 u.set("openvpn", iname, 'ca', os.path.join(cert_dir, 'ca.crt'))
-u.set("openvpn", iname, 'cert', os.path.join(cert_dir, 'srv.crt'))
-u.set("openvpn", iname, 'key', os.path.join(cert_dir, 'srv.key'))
-u.set("openvpn", iname, 'crl-verify', os.path.join(cert_dir, 'crl.pem'))
+u.set("openvpn", iname, 'cert', os.path.join(cert_dir, 'issued/server.crt'))
+u.set("openvpn", iname, 'key', os.path.join(cert_dir, 'private/server.key'))
+u.set("openvpn", iname, 'key', os.path.join(cert_dir, 'private/ca.key'))
+u.set("openvpn", iname, 'crl_verify', os.path.join(cert_dir, 'crl.pem'))
 
 u.set("openvpn", iname, 'client_connect', f'"/usr/libexec/ns-openvpn/openvpn-connect {iname}"')
 u.set("openvpn", iname, 'client_disconnect', f'"/usr/libexec/ns-openvpn/openvpn-disconnect {iname}"')
@@ -55,8 +62,8 @@ for user in data["users"]:
     u.set("openvpn", sname, "instance", iname)
     u.set("openvpn", sname, "ipaddr", user["ipaddr"])
     u.set("openvpn", sname, "enabled", user["enabled"])
-    save_cert(os.path.join(cert_dir, f'{sname}.key'), user['key'])
-    save_cert(os.path.join(cert_dir, f'{sname}.crt'), user['crt'])
+    save_cert(os.path.join(cert_dir, f'private/{sname}.key'), user['key'])
+    save_cert(os.path.join(cert_dir, f'issued/{sname}.crt'), user['crt'])
 
 # Add interface to LAN
 firewall.add_to_lan(u, data['rw']['options']['dev'])

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -9,8 +9,8 @@ import os
 import pwd
 import grp
 import os.path
-import fwutils
-from nextsec import firewall
+import nsmigration
+from nextsec import firewall, utils
 
 def save_cert(path, data):
     # setup rw permissions on ly for nobody user
@@ -27,12 +27,12 @@ iname="roadwarrior"
 cert_dir=f"/etc/openvpn/{iname}/certs"
 os.makedirs(cert_dir, exist_ok=True)
 
-(u, data) = fwutils.init("openvpn.json")
+(u, data) = nsmigration.init("openvpn.json")
 
 # Setup global option
 u.set("openvpn", iname, "openvpn")
 for option in data['rw']['options']:
-    fwutils.vprint(f"Setting OpenVPN roadwarrior option {option}")
+    nsmigration.vprint(f"Setting OpenVPN roadwarrior option {option}")
     u.set("openvpn", iname, option, data['rw']['options'][option])
 
 # Setup server certificates
@@ -49,8 +49,8 @@ u.set("openvpn", iname, 'client_disconnect', f'"/usr/libexec/ns-openvpn/openvpn-
 
 # Create user entries
 for user in data["users"]:
-    sname = fwutils.sanitize(user["name"])
-    fwutils.vprint(f"Creating OpenVPN roadwarrior user {sname}")
+    sname = utils.sanitize(user["name"])
+    nsmigration.vprint(f"Creating OpenVPN roadwarrior user {sname}")
     u.set("openvpn", sname, "user")
     u.set("openvpn", sname, "instance", iname)
     u.set("openvpn", sname, "ipaddr", user["ipaddr"])
@@ -61,7 +61,7 @@ for user in data["users"]:
 # Add interface to LAN
 firewall.add_to_lan(u, data['rw']['options']['dev'])
 # Open OpenVPN port
-firewall.allow_service(u, 'openvpn_rw', data['rw']['options']['port'], data['rw']['options']['proto'])
+firewall.add_service(u, 'openvpn_rw', data['rw']['options']['port'], data['rw']['options']['proto'])
 
 # Save configuration
 u.commit("openvpn")

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import os
+import pwd
+import grp
+import os.path
+import fwutils
+
+def save_cert(path, data):
+    # setup rw permissions on ly for nobody user
+    os.umask(0o077)
+    with open(path, 'w') as f:
+        f.write(data)
+    
+    uid = pwd.getpwnam("nobody").pw_uid
+    gid = grp.getgrnam("nogroup").gr_gid
+    os.chown(path, uid, gid)
+
+
+iname="roadwarrior"
+cert_dir=f"/etc/openvpn/{iname}/certs"
+os.makedirs(cert_dir, exist_ok=True)
+
+(u, data) = fwutils.init("openvpn.json")
+
+# Setup global option
+u.set("openvpn", iname, "openvpn")
+for option in data['rw']['options']:
+    fwutils.vprint(f"Setting OpenVPN roadwarrior option {option}")
+    u.set("openvpn", iname, option, data['rw']['options'][option])
+
+# Setup server certificates
+for cert in data['rw']['ca']:
+    save_cert(os.path.join(cert_dir, cert), data['rw']['ca'][cert])
+u.set("openvpn", iname, 'dh', os.path.join(cert_dir, 'dh.pem'))
+u.set("openvpn", iname, 'ca', os.path.join(cert_dir, 'ca.crt'))
+u.set("openvpn", iname, 'cert', os.path.join(cert_dir, 'srv.crt'))
+u.set("openvpn", iname, 'key', os.path.join(cert_dir, 'srv.key'))
+u.set("openvpn", iname, 'crl-verify', os.path.join(cert_dir, 'crl.pem'))
+
+u.set("openvpn", iname, 'client_connect', f'"/usr/libexec/ns-openvpn/openvpn-connect {iname}"')
+u.set("openvpn", iname, 'client_disconnect', f'"/usr/libexec/ns-openvpn/openvpn-disconnect {iname}"')
+
+# Create user entries
+for user in data["users"]:
+    sname = fwutils.sanitize(user["name"])
+    fwutils.vprint(f"Creating OpenVPN roadwarrior user {sname}")
+    u.set("openvpn", sname, "user")
+    u.set("openvpn", sname, "instance", iname)
+    u.set("openvpn", sname, "ipaddr", user["ipaddr"])
+    u.set("openvpn", sname, "enabled", user["enabled"])
+    save_cert(os.path.join(cert_dir, f'{sname}.key'), user['key'])
+    save_cert(os.path.join(cert_dir, f'{sname}.crt'), user['crt'])
+
+# Add interface to wan
+for section in u.get("firewall"):
+    s_type = u.get("firewall", section)
+    if s_type == "zone":
+        zname = u.get("firewall", section, "name")
+        if zname == "lan":
+            try:
+                devices = u.get_all("firewall", section, "device")
+            except:
+                devices = []
+            if not data['rw']['options']['dev'] in devices:
+                fwutils.vprint(f"Adding OpenVPN device to lan zone")
+                devices.append(data['rw']['options']['dev'])
+                u.set("firewall", section, "device", devices)
+
+# Open OpenVPN port
+rname="allow_openvpn_rw"
+u.set("firewall", rname, "rule")
+u.set("firewall", rname, "name", "Allow-OpenVPN-RW")
+u.set("firewall", rname, "src", "wan")
+u.set("firewall", rname, "dest_port", data['rw']['options']['port'])
+u.set("firewall", rname, "proto", data['rw']['options']['proto'])
+u.set("firewall", rname, "target", "ACCEPT")
+
+# Save configuration
+u.commit("openvpn")
+u.commit("firewall")

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -10,6 +10,7 @@ import pwd
 import grp
 import os.path
 import fwutils
+from nextsec import firewall
 
 def save_cert(path, data):
     # setup rw permissions on ly for nobody user
@@ -57,30 +58,11 @@ for user in data["users"]:
     save_cert(os.path.join(cert_dir, f'{sname}.key'), user['key'])
     save_cert(os.path.join(cert_dir, f'{sname}.crt'), user['crt'])
 
-# Add interface to wan
-for section in u.get("firewall"):
-    s_type = u.get("firewall", section)
-    if s_type == "zone":
-        zname = u.get("firewall", section, "name")
-        if zname == "lan":
-            try:
-                devices = u.get_all("firewall", section, "device")
-            except:
-                devices = []
-            if not data['rw']['options']['dev'] in devices:
-                fwutils.vprint(f"Adding OpenVPN device to lan zone")
-                devices.append(data['rw']['options']['dev'])
-                u.set("firewall", section, "device", devices)
-
+# Add interface to LAN
+firewall.add_to_lan(u, data['rw']['options']['dev'])
 # Open OpenVPN port
-rname="allow_openvpn_rw"
-u.set("firewall", rname, "rule")
-u.set("firewall", rname, "name", "Allow-OpenVPN-RW")
-u.set("firewall", rname, "src", "wan")
-u.set("firewall", rname, "dest_port", data['rw']['options']['port'])
-u.set("firewall", rname, "proto", data['rw']['options']['proto'])
-u.set("firewall", rname, "target", "ACCEPT")
+firewall.allow_service(u, 'openvpn_rw', data['rw']['options']['port'], data['rw']['options']['proto'])
 
 # Save configuration
 u.commit("openvpn")
-u.commit("firewall")
+firewall.apply(u)

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -69,7 +69,7 @@ for user in data["users"]:
 ovpn_interface = firewall.add_vpn_interface(u, 'openvpnrw', data['rw']['options']['dev'])
 ovpn_zone = firewall.add_trusted_zone(u, "openvpnrw", [ovpn_interface])
 # Open OpenVPN port
-firewall.add_service(u, 'openvpn_rw', data['rw']['options']['port'], data['rw']['options']['proto'])
+firewall.add_service(u, 'openvpnrw', data['rw']['options']['port'], data['rw']['options']['proto'])
 
 # Save configuration
 u.commit("openvpn")

--- a/packages/ns-migration/files/scripts/redirects
+++ b/packages/ns-migration/files/scripts/redirects
@@ -5,23 +5,23 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+import nsmigration
 
-(u, data) = fwutils.init("redirects.json")
+(u, data) = nsmigration.init("redirects.json")
 
 for pf in data['redirects']:
     name = pf.pop("key")
     sname = f"{name}_ipset"
     desc = pf.pop("description")
     # create ipset
-    fwutils.vprint(f'Creating ipset {sname} for port forward {name}')
+    nsmigration.vprint(f'Creating ipset {sname} for port forward {name}')
     u.set("firewall", sname, "ipset")
     u.set("firewall", sname, "name", sname)
     u.set("firewall", sname, "match", "src_net")
     u.set("firewall", sname, "enabled", "1")
     u.set("firewall", sname, "entry", pf.pop("src_ip"))
     # create port forward 
-    fwutils.vprint(f'Creating port forward {name}')
+    nsmigration.vprint(f'Creating port forward {name}')
     u.set("firewall", name, "redirect")
     u.set("firewall", name, "name", desc)
     u.set("firewall", name, "src", 'wan')

--- a/packages/ns-migration/files/scripts/redirects
+++ b/packages/ns-migration/files/scripts/redirects
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import fwutils
+
+(u, data) = fwutils.init("redirects.json")
+
+for pf in data['redirects']:
+    name = pf.pop("key")
+    sname = f"{name}_ipset"
+    desc = pf.pop("description")
+    # create ipset
+    fwutils.vprint(f'Creating ipset {sname} for port forward {name}')
+    u.set("firewall", sname, "ipset")
+    u.set("firewall", sname, "name", sname)
+    u.set("firewall", sname, "match", "src_net")
+    u.set("firewall", sname, "enabled", "1")
+    u.set("firewall", sname, "entry", pf.pop("src_ip"))
+    # create port forward 
+    fwutils.vprint(f'Creating port forward {name}')
+    u.set("firewall", name, "redirect")
+    u.set("firewall", name, "name", desc)
+    u.set("firewall", name, "src", 'wan')
+    u.set("firewall", name, "ipset", f"{sname}")
+    for o in pf:
+        u.set("firewall", name, o, pf[o])
+
+# Save configuration
+u.commit("firewall")

--- a/packages/ns-migration/files/scripts/redirects
+++ b/packages/ns-migration/files/scripts/redirects
@@ -8,7 +8,7 @@
 import nsmigration
 from nextsec import utils
 
-(u, data) = nsmigration.init("redirects.json")
+(u, data, nmap) = nsmigration.init("redirects.json")
 
 for pf in data['redirects']:
     name = pf.pop("key")

--- a/packages/ns-migration/files/scripts/redirects
+++ b/packages/ns-migration/files/scripts/redirects
@@ -6,28 +6,32 @@
 #
 
 import nsmigration
+from nextsec import utils
 
 (u, data) = nsmigration.init("redirects.json")
 
 for pf in data['redirects']:
     name = pf.pop("key")
-    sname = f"{name}_ipset"
+    pfname = utils.get_id(name)
+    sname = utils.get_id(f"{name}_ipset")
     desc = pf.pop("description")
     # create ipset
-    nsmigration.vprint(f'Creating ipset {sname} for port forward {name}')
+    nsmigration.vprint(f'Creating ipset {sname} for port forward {pfname}')
     u.set("firewall", sname, "ipset")
     u.set("firewall", sname, "name", sname)
     u.set("firewall", sname, "match", "src_net")
     u.set("firewall", sname, "enabled", "1")
     u.set("firewall", sname, "entry", pf.pop("src_ip"))
     # create port forward 
-    nsmigration.vprint(f'Creating port forward {name}')
-    u.set("firewall", name, "redirect")
-    u.set("firewall", name, "name", desc)
-    u.set("firewall", name, "src", 'wan')
-    u.set("firewall", name, "ipset", f"{sname}")
+    nsmigration.vprint(f'Creating port forward {pfname}')
+    u.set("firewall", pfname, "redirect")
+    u.set("firewall", pfname, "name", desc)
+    u.set("firewall", pfname, "src", 'wan')
+    u.set("firewall", pfname, "ipset", f"{sname}")
+    # this should be irrelevant for DNAT, but it prevents a warning
+    u.set("firewall", pfname, "dest", "lan")
     for o in pf:
-        u.set("firewall", name, o, pf[o])
+        u.set("firewall", pfname, o, pf[o])
 
 # Save configuration
 u.commit("firewall")

--- a/packages/ns-migration/files/scripts/routes
+++ b/packages/ns-migration/files/scripts/routes
@@ -13,6 +13,7 @@ counter = len(data['routes'])
 
 for route in data['routes']:
     rname = f'route{counter}'
+    fwutils.vprint(f'Creating route {rname}')
     route['interface'] = fwutils.get_interface_name(u, route['interface'])
     u.set("network", rname, "route")
     for option in route:

--- a/packages/ns-migration/files/scripts/routes
+++ b/packages/ns-migration/files/scripts/routes
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import fwutils
+
+(u, data) = fwutils.init("routes.json")
+
+counter = len(data['routes'])
+
+for route in data['routes']:
+    rname = f'route{counter}'
+    route['interface'] = fwutils.get_interface_name(u, route['interface'])
+    u.set("network", rname, "route")
+    for option in route:
+        u.set("network", rname, option, route[option])
+
+
+# Save configuration
+u.commit("network")

--- a/packages/ns-migration/files/scripts/routes
+++ b/packages/ns-migration/files/scripts/routes
@@ -8,14 +8,14 @@
 import nsmigration
 from nextsec import firewall, utils
 
-(u, data) = nsmigration.init("routes.json")
+(u, data, nmap) = nsmigration.init("routes.json")
 
 counter = len(data['routes'])
 
 for route in data['routes']:
     rname = utils.get_id(f'route{counter}')
     nsmigration.vprint(f'Creating route {rname}')
-    route['interface'] = firewall.get_interface_name(u, route['interface'])
+    route['interface'] = firewall.get_interface_name(u, nsmigration.remap(route['interface'], nmap))
     u.set("network", rname, "route")
     for option in route:
         u.set("network", rname, option, route[option])

--- a/packages/ns-migration/files/scripts/routes
+++ b/packages/ns-migration/files/scripts/routes
@@ -6,14 +6,14 @@
 #
 
 import nsmigration
-from nextsec import firewall
+from nextsec import firewall, utils
 
 (u, data) = nsmigration.init("routes.json")
 
 counter = len(data['routes'])
 
 for route in data['routes']:
-    rname = f'route{counter}'
+    rname = utils.get_id(f'route{counter}')
     nsmigration.vprint(f'Creating route {rname}')
     route['interface'] = firewall.get_interface_name(u, route['interface'])
     u.set("network", rname, "route")

--- a/packages/ns-migration/files/scripts/routes
+++ b/packages/ns-migration/files/scripts/routes
@@ -5,20 +5,20 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+import nsmigration
+from nextsec import firewall
 
-(u, data) = fwutils.init("routes.json")
+(u, data) = nsmigration.init("routes.json")
 
 counter = len(data['routes'])
 
 for route in data['routes']:
     rname = f'route{counter}'
-    fwutils.vprint(f'Creating route {rname}')
-    route['interface'] = fwutils.get_interface_name(u, route['interface'])
+    nsmigration.vprint(f'Creating route {rname}')
+    route['interface'] = firewall.get_interface_name(u, route['interface'])
     u.set("network", rname, "route")
     for option in route:
         u.set("network", rname, option, route[option])
-
 
 # Save configuration
 u.commit("network")

--- a/packages/ns-migration/files/scripts/rules
+++ b/packages/ns-migration/files/scripts/rules
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import nsmigration
+from nextsec import firewall, utils
+
+(u, data) = nsmigration.init("rules.json")
+
+def by_position(e):
+    return e["position"]
+
+data['rules'].sort(key=by_position)
+
+for rule in data['rules']:
+    rname = utils.get_id(rule.pop('key'))
+    rule['name'] = utils.sanitize(rule['name'])
+    del rule['position']
+    nsmigration.vprint(f"Creating firewall rule {rname}")
+    u.set("firewall", rname, "rule")
+    try:
+        u.get("firewall", utils.get_id(rule['dest']))
+        u.get("firewall", utils.get_id(rule['src']))
+    except:
+        nsmigration.vprint(f"Disabling firewall rule {rname}")
+        rule["enabled"] = 0
+
+    for o in rule:
+        u.set("firewall", rname, o, rule[o])
+
+# Save configuration
+u.commit("firewall")

--- a/packages/ns-migration/files/scripts/rules
+++ b/packages/ns-migration/files/scripts/rules
@@ -8,7 +8,7 @@
 import nsmigration
 from nextsec import firewall, utils
 
-(u, data) = nsmigration.init("rules.json")
+(u, data, nmap) = nsmigration.init("rules.json")
 
 def by_position(e):
     return e["position"]

--- a/packages/ns-migration/files/scripts/ssh
+++ b/packages/ns-migration/files/scripts/ssh
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import fwutils
+
+(u, data) = fwutils.init("ssh.json")
+
+# Set global options
+for section in u.get("dropbear"):
+    if  u.get("dropbear", section) == "dropbear":
+        for option in data['ssh']:
+            u.set("dropbear", section, option, data['ssh'][option])
+
+with open('/etc/dropbear/authorized_keys', 'w') as f:
+    f.write(data['authorized_keys'])
+
+if data['ssh_from_wan']:
+    section =  "Allow_SSH_from_WAN"
+    u.set("firewall", section, 'rule')
+    u.set("firewall", section, 'name', section.replace("_","-"))
+    u.set("firewall", section, 'proto', 'tcp')
+    u.set("firewall", section, 'src', 'wan')
+    u.set("firewall", section, 'target', 'ACCEPT')
+    u.set("firewall", section, 'dest_port', data['ssh']['Port'])
+    u.commit("firewall")
+
+# Save configuration
+u.commit("dropbear")

--- a/packages/ns-migration/files/scripts/ssh
+++ b/packages/ns-migration/files/scripts/ssh
@@ -13,12 +13,16 @@ import fwutils
 for section in u.get("dropbear"):
     if  u.get("dropbear", section) == "dropbear":
         for option in data['ssh']:
+            fwutils.vprint(f"Setting SSH option {option}")
             u.set("dropbear", section, option, data['ssh'][option])
 
-with open('/etc/dropbear/authorized_keys', 'w') as f:
-    f.write(data['authorized_keys'])
+if data['authorized_keys']:
+    fwutils.vprint(f"Setting SSH authorized_keys")
+    with open('/etc/dropbear/authorized_keys', 'w') as f:
+        f.write(data['authorized_keys'])
 
 if data['ssh_from_wan']:
+    fwutils.vprint(f"Allowing SSH access from WAN")
     section =  "Allow_SSH_from_WAN"
     u.set("firewall", section, 'rule')
     u.set("firewall", section, 'name', section.replace("_","-"))

--- a/packages/ns-migration/files/scripts/ssh
+++ b/packages/ns-migration/files/scripts/ssh
@@ -5,31 +5,26 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+import nsmigration
+from nextsec import firewall
 
-(u, data) = fwutils.init("ssh.json")
+(u, data) = nsmigration.init("ssh.json")
 
 # Set global options
 for section in u.get("dropbear"):
     if  u.get("dropbear", section) == "dropbear":
         for option in data['ssh']:
-            fwutils.vprint(f"Setting SSH option {option}")
+            nsmigration.vprint(f"Setting SSH option {option}")
             u.set("dropbear", section, option, data['ssh'][option])
 
 if data['authorized_keys']:
-    fwutils.vprint(f"Setting SSH authorized_keys")
+    nsmigration.vprint(f"Setting SSH authorized_keys")
     with open('/etc/dropbear/authorized_keys', 'w') as f:
         f.write(data['authorized_keys'])
 
 if data['ssh_from_wan']:
-    fwutils.vprint(f"Allowing SSH access from WAN")
-    section =  "Allow_SSH_from_WAN"
-    u.set("firewall", section, 'rule')
-    u.set("firewall", section, 'name', section.replace("_","-"))
-    u.set("firewall", section, 'proto', 'tcp')
-    u.set("firewall", section, 'src', 'wan')
-    u.set("firewall", section, 'target', 'ACCEPT')
-    u.set("firewall", section, 'dest_port', data['ssh']['Port'])
+    nsmigration.vprint(f"Allowing SSH access from WAN")
+    firewall.add_service(u, 'ssh', data['ssh']['Port'], 'tcp')
     u.commit("firewall")
 
 # Save configuration

--- a/packages/ns-migration/files/scripts/ssh
+++ b/packages/ns-migration/files/scripts/ssh
@@ -8,7 +8,7 @@
 import nsmigration
 from nextsec import firewall
 
-(u, data) = nsmigration.init("ssh.json")
+(u, data, nmap) = nsmigration.init("ssh.json")
 
 # Set global options
 for section in u.get("dropbear"):

--- a/packages/ns-migration/files/scripts/subscription
+++ b/packages/ns-migration/files/scripts/subscription
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import fwutils
+
+(u, data) = fwutils.init("subscription.json")
+
+if data['subscription']['system_id']:
+    u.set('ns-plug', 'config', 'system_id', data['subscription']['system_id'])
+
+if data['subscription']['secret']:
+    u.set('ns-plug', 'config', 'secret', data['subscription']['secret'])
+
+# Save configuration
+u.commit("ns-plug")

--- a/packages/ns-migration/files/scripts/subscription
+++ b/packages/ns-migration/files/scripts/subscription
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+import nsmigration
 
-(u, data) = fwutils.init("subscription.json")
+(u, data) = nsmigration.init("subscription.json")
 
 if data['subscription']['system_id']:
     u.set('ns-plug', 'config', 'system_id', data['subscription']['system_id'])

--- a/packages/ns-migration/files/scripts/subscription
+++ b/packages/ns-migration/files/scripts/subscription
@@ -10,9 +10,11 @@ import nsmigration
 (u, data) = nsmigration.init("subscription.json")
 
 if data['subscription']['system_id']:
+    nsmigration.vprint(f"Setting subscription system_id")
     u.set('ns-plug', 'config', 'system_id', data['subscription']['system_id'])
 
 if data['subscription']['secret']:
+    nsmigration.vprint(f"Setting subscription secret")
     u.set('ns-plug', 'config', 'secret', data['subscription']['secret'])
 
 # Save configuration

--- a/packages/ns-migration/files/scripts/subscription
+++ b/packages/ns-migration/files/scripts/subscription
@@ -7,7 +7,7 @@
 
 import nsmigration
 
-(u, data) = nsmigration.init("subscription.json")
+(u, data, nmap) = nsmigration.init("subscription.json")
 
 if data['subscription']['system_id']:
     nsmigration.vprint(f"Setting subscription system_id")

--- a/packages/ns-migration/files/scripts/threat_shield
+++ b/packages/ns-migration/files/scripts/threat_shield
@@ -7,7 +7,7 @@
 
 import nsmigration
 
-(u, data) = nsmigration.init("threat_shield.json")
+(u, data, nmap) = nsmigration.init("threat_shield.json")
 
 for o in data['ts-ip']:
     u.set('threat_shield', 'config', o, data['ts-ip'][o])

--- a/packages/ns-migration/files/scripts/threat_shield
+++ b/packages/ns-migration/files/scripts/threat_shield
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+import nsmigration
 
-(u, data) = fwutils.init("threat_shield.json")
+(u, data) = nsmigration.init("threat_shield.json")
 
 for o in data['ts-ip']:
     u.set('threat_shield', 'config', o, data['ts-ip'][o])

--- a/packages/ns-migration/files/scripts/threat_shield
+++ b/packages/ns-migration/files/scripts/threat_shield
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import fwutils
+
+(u, data) = fwutils.init("threat_shield.json")
+
+for o in data['ts-ip']:
+    u.set('threat_shield', 'config', o, data['ts-ip'][o])
+u.set('threat_shield', 'config', 'log_blocked', '1')
+
+for o in data['ts-dns']:
+    u.set('adblock', 'global', o, data['ts-dns'][o])
+
+# Save configuration
+u.commit("adblock")
+u.commit("threat_shield")

--- a/packages/ns-migration/files/scripts/time
+++ b/packages/ns-migration/files/scripts/time
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import fwutils
+
+(u, data) = fwutils.init("time.json")
+
+# Set global options
+for option in data['ntp']:
+    fwutils.vprint(f"Setting NTP option {option}")
+    u.set("system", "ntp", option, data['ntp'][option])
+
+for section in u.get("system"):
+    if  u.get("system", section) == "timezone":
+        fwutils.vprint(f"Setting timezone")
+        u.set("system", section, "timezone", data['timezone'])
+
+# Save configuration
+u.commit("system")

--- a/packages/ns-migration/files/scripts/time
+++ b/packages/ns-migration/files/scripts/time
@@ -5,18 +5,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import fwutils
+import nsmigration
 
-(u, data) = fwutils.init("time.json")
+(u, data) = nsmigration.init("time.json")
 
 # Set global options
 for option in data['ntp']:
-    fwutils.vprint(f"Setting NTP option {option}")
+    nsmigration.vprint(f"Setting NTP option {option}")
     u.set("system", "ntp", option, data['ntp'][option])
 
 for section in u.get("system"):
     if  u.get("system", section) == "timezone":
-        fwutils.vprint(f"Setting timezone")
+        nsmigration.vprint(f"Setting timezone")
         u.set("system", section, "timezone", data['timezone'])
 
 # Save configuration

--- a/packages/ns-migration/files/scripts/time
+++ b/packages/ns-migration/files/scripts/time
@@ -7,7 +7,7 @@
 
 import nsmigration
 
-(u, data) = nsmigration.init("time.json")
+(u, data, nmap) = nsmigration.init("time.json")
 
 # Set global options
 for option in data['ntp']:

--- a/packages/ns-migration/files/scripts/wan
+++ b/packages/ns-migration/files/scripts/wan
@@ -8,7 +8,7 @@
 import nsmigration
 from nextsec import firewall, utils
 
-(u, data) = nsmigration.init("wan.json")
+(u, data, nmap) = nsmigration.init("wan.json")
 
 def by_weight(e):
     return e["weight"]
@@ -33,7 +33,10 @@ divert_policies = dict()
 # Create interfaces and members
 metric = 10
 for p in data['providers']:
-    iname = firewall.get_interface_name(u, p["device"])
+    iname = firewall.get_interface_name(u, nsmigration.remap(p["device"], nmap))
+    if iname is None:
+        nsmigration.vprint(f"Skipping mwan interface {p['device']}")
+        continue
     nsmigration.vprint(f"Creating mwan interface {iname}")
     u.set("mwan3", iname, "interface")
     u.set("mwan3", iname, "enabled", "1")

--- a/packages/ns-migration/files/scripts/wan
+++ b/packages/ns-migration/files/scripts/wan
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import nsmigration
+from nextsec import firewall, utils
+
+(u, data) = nsmigration.init("wan.json")
+
+def by_weight(e):
+    return e["weight"]
+
+# Cleanup default configuration
+u.delete("mwan3", "https")
+for section in u.get("mwan3"):
+    s_type = u.get("mwan3", section)
+    if s_type == "interface" or s_type == "member" or s_type == "policy":
+        u.delete("mwan3", section)
+    if s_type == "rule" and not section.startswith("ns_"):
+        u.rename("mwan3", section, f"ns_{section}")
+
+# Sort providers to setup metric
+# lower metric => higher priority
+data['providers'].sort(key=by_weight, reverse=True)
+
+# Create interfaces and members
+metric = 10
+for p in data['providers']:
+    iname = firewall.get_interface_name(u, p["device"])
+    nsmigration.vprint(f"Creating mwan interface {iname}")
+    u.set("mwan3", iname, "interface")
+    u.set("mwan3", iname, "enabled", "1")
+    u.set("mwan3", iname, "family", "ipv4")
+    u.set("mwan3", iname, "track_ip", data['general']['track_ip'])
+    u.set("mwan3", iname, "reliability", data['general']['reliability'])
+
+    nsmigration.vprint(f"Setting mwan metric for {iname}")
+    u.set("network", iname, 'metric', metric)
+
+    nsmigration.vprint(f"Setting mwan member for {iname}")
+    mname = utils.get_id(f"{iname}_m{metric}_w{p['weight']}")
+    u.set("mwan3", mname, "member")
+    u.set("mwan3", mname, "interface", iname)
+    u.set("mwan3", mname, "weight", p["weight"])
+
+    if data["general"]["mode"] == "balance":
+        # same metric => same priority
+        u.set("mwan3", mname, "metric", "50")
+    else:
+        u.set("mwan3", mname, "metric", metric)
+
+    metric = metric + 10
+
+# Setup policy
+    pname = utils.get_id("ns7balance")
+else:
+    pname = utils.get_id("ns7backup")
+u.set("mwan3", pname, "policy")
+u.set("mwan3", pname, "use_member", list(utils.get_all_by_type(u, "mwan3", "member").keys()))
+    
+# Save configuration
+u.commit("mwan3")
+u.commit("network")

--- a/packages/ns-migration/files/scripts/wan
+++ b/packages/ns-migration/files/scripts/wan
@@ -13,18 +13,22 @@ from nextsec import firewall, utils
 def by_weight(e):
     return e["weight"]
 
+def by_position(e):
+    return e["position"]
+
 # Cleanup default configuration
 u.delete("mwan3", "https")
 for section in u.get("mwan3"):
     s_type = u.get("mwan3", section)
-    if s_type == "interface" or s_type == "member" or s_type == "policy":
+    if s_type != "globals":
         u.delete("mwan3", section)
-    if s_type == "rule" and not section.startswith("ns_"):
-        u.rename("mwan3", section, f"ns_{section}")
 
 # Sort providers to setup metric
 # lower metric => higher priority
 data['providers'].sort(key=by_weight, reverse=True)
+
+# map NS7 provider name to mwan polices
+divert_policies = dict()
 
 # Create interfaces and members
 metric = 10
@@ -52,15 +56,47 @@ for p in data['providers']:
     else:
         u.set("mwan3", mname, "metric", metric)
 
+    # Setup policy with only this interface
+    # The policy will be used for divert rules
+    ponly = utils.get_id(f'{iname}', length = 15)
+    u.set("mwan3", ponly, "policy")
+    u.set("mwan3", ponly, "use_member", mname)
+    divert_policies[p["name"]] = ponly
+
     metric = metric + 10
 
-# Setup policy
-    pname = utils.get_id("ns7balance")
+# Setup default policy
+    pname = utils.get_id("ns7balance", length = 15)
 else:
-    pname = utils.get_id("ns7backup")
+    pname = utils.get_id("ns7backup", length = 15)
 u.set("mwan3", pname, "policy")
 u.set("mwan3", pname, "use_member", list(utils.get_all_by_type(u, "mwan3", "member").keys()))
-    
+
+# Sort rules in reverse order
+# On NS7 last match wins
+data['rules'].sort(key=by_position, reverse=True)
+
+for rule in data['rules']:
+    rname = utils.get_id(rule.pop('name'))
+    rule["use_policy"]  = divert_policies[rule["use_policy"]]
+    nsmigration.vprint(f"Setting mwan rule {rname}")
+    u.set("mwan3", rname, 'rule')
+    u.set("mwan3", rname, 'family', 'ipv4')
+    for o in rule:
+        u.set("mwan3", rname, o, rule[o])
+
+def_v4 = utils.get_id('default_v4', length = 15)
+u.set("mwan3", def_v4, 'rule')
+u.set("mwan3", def_v4, 'dest_ip', '0.0.0.0/0')
+u.set("mwan3", def_v4, 'use_policy', pname)
+u.set("mwan3", def_v4, 'family', 'ipv4')
+
+def_v6 = utils.get_id('default_v6', length = 15)
+u.set("mwan3", def_v6, 'rule')
+u.set("mwan3", def_v6, 'dest_ip', '::/0')
+u.set("mwan3", def_v6, 'use_policy', pname)
+u.set("mwan3", def_v6, 'family', 'ipv6')
+
 # Save configuration
 u.commit("mwan3")
 u.commit("network")


### PR DESCRIPTION
Add a new `ns-migration` package to handle the migration from NS7 firewall. 

Import:
- DHCP ranges
- DHCP static leases (reservations)
- Number of max leases
- Network configuration
- Firewall zones
- DNS records (local and remote)
- Machine hostname and domain
- Wildcard DNS records
- Static routes
- SSH configuration (with some limitation)
- NTP
- Timezone
- Subscription
- Port forward
- Threat shield (see also #29 and #24)

Following configurations are not currently migrated:
- Network bridges and bonds
- PPPoE WAN
- QoS rules and bandwitdh configuration
- Hotspot firewall role and hotspot application (dedalo)
- OpenVPN tunnels
- IPSec tunnels

See also NS7 configuration exporter: https://github.com/NethServer/nethserver-firewall-migration