### PR TITLE
files: add automatic import script

### DIFF
--- a/files/etc/uci-defaults/95-nextsec-migrate
+++ b/files/etc/uci-defaults/95-nextsec-migrate
@@ -1,0 +1,8 @@
+archive="/usr/share/migration/export.tar.gz"
+if [ -f "${archive}" ]; then
+    /usr/sbin/ns-import $archive | tee /dev/kmsg
+
+    if [ $? -eq 0 ]; then
+        mv "${archive}" "${archive}.done"
+    fi
+fi


### PR DESCRIPTION
Automatically call ns-import on /usr/share/migration/export.tar.gz. The script imports will be executed only on first boot and after the upgrade.

See also https://github.com/NethServer/nethserver-firewall-migration/pull/7