### PR TITLE
Reverse proxy and Let's Encrypt support

### DIFF
--- a/config/acme.conf
+++ b/config/acme.conf
@@ -1,0 +1,4 @@
+CONFIG_PACKAGE_luci-app-acme=y
+CONFIG_PACKAGE_acme=y
+CONFIG_PACKAGE_acme-dnsapi=y
+CONFIG_PACKAGE_socat=y

--- a/config/ns-reverse-proxy.conf
+++ b/config/ns-reverse-proxy.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_ns-reverse-proxy=y

--- a/files/etc/board.d/40virtual
+++ b/files/etc/board.d/40virtual
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+. /lib/functions/system.sh
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+case "$(board_name)" in
+qemu-standard*)
+	ucidef_set_interface_lan "eth0" "dhcp"
+	ucidef_set_interface_wan "eth1" "dhcp"
+	;;
+digitalocean-droplet*)
+	ucidef_set_interface_lan "eth1" "dhcp"
+	ucidef_set_interface_wan "eth0" "dhcp"
+	;;
+esac
+board_config_flush
+
+exit 0

--- a/files/etc/uci-defaults/99-nextsec-webui
+++ b/files/etc/uci-defaults/99-nextsec-webui
@@ -8,3 +8,8 @@ set firewall.@rule[-1].dest_port='443'
 set firewall.@rule[-1].target='ACCEPT'
 commit
 EOI
+
+uci batch <<EOI
+del_list nginx._lan.include=restrict_locally
+commit
+EOI

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -53,6 +53,7 @@ define Package/ns-migration/install
 	$(INSTALL_BIN) ./files/scripts/hotspot $(1)/usr/share/ns-migration/40hotspot
 	$(INSTALL_BIN) ./files/scripts/rules $(1)/usr/share/ns-migration/50rules
 	$(INSTALL_BIN) ./files/scripts/redirects $(1)/usr/share/ns-migration/50redirects
+	$(INSTALL_BIN) ./files/scripts/reverse_proxy $(1)/usr/share/ns-migration/60reverse_proxy
 	$(INSTALL_BIN) ./files/scripts/threat_shield $(1)/usr/share/ns-migration/70threat_shield
 	$(INSTALL_BIN) ./files/scripts/flashstart $(1)/usr/share/ns-migration/70flashstart
 	$(INSTALL_BIN) ./files/scripts/acme $(1)/usr/share/ns-migration/80acme

--- a/packages/ns-migration/Makefile
+++ b/packages/ns-migration/Makefile
@@ -55,6 +55,7 @@ define Package/ns-migration/install
 	$(INSTALL_BIN) ./files/scripts/redirects $(1)/usr/share/ns-migration/50redirects
 	$(INSTALL_BIN) ./files/scripts/threat_shield $(1)/usr/share/ns-migration/70threat_shield
 	$(INSTALL_BIN) ./files/scripts/flashstart $(1)/usr/share/ns-migration/70flashstart
+	$(INSTALL_BIN) ./files/scripts/acme $(1)/usr/share/ns-migration/80acme
 	$(INSTALL_DATA) ./files/scripts/nsmigration.py $(1)/usr/share/ns-migration/
 endef
  

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -268,6 +268,19 @@ MAC address. In this case, the unit must be manually registered to the remote Ic
    dedalo restart
    ```
 
+## Let's Encrypt certificate
+
+The `acme` script will import:
+
+- Let's Encrypt account mail
+- certificate domains list
+
+Let's Encrypt certificates will not be migrated, but regenerated at the end of import process.
+
+The following NS7 options will not be migrated:
+
+- `LetsEncryptChallenge`, it's fixed to `http`
+
 ## Cloud DNS filter (Flashstart)
 
 The `flashstart` script will import:

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -281,6 +281,21 @@ The following NS7 options will not be migrated:
 
 - `LetsEncryptChallenge`, it's fixed to `http`
 
+## Reverse proxy (proxy pass)
+
+The `reverse_proxy` script will import:
+
+- all path based rules
+- all host based rules
+
+The following NS7 options will not be migrated:
+
+- `HTTP` and `HTTPS`
+
+Differences since NS7:
+
+- redirection from HTTP to HTTPS is always enabled
+
 ## Cloud DNS filter (Flashstart)
 
 The `flashstart` script will import:

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -82,3 +82,4 @@ try_restart mwan3
 try_restart swanctl
 try_restart dedalo
 try_restart qosify
+service acme start

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -83,3 +83,5 @@ try_restart swanctl
 try_restart dedalo
 try_restart qosify
 service acme start
+nginx-proxy
+try_restart nginx

--- a/packages/ns-migration/files/scripts/acme
+++ b/packages/ns-migration/files/scripts/acme
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import sys
+import nsmigration
+
+(u, data, nmap) = nsmigration.init("acme.json")
+
+if 'config' not in data:
+    sys.exit(0)
+
+u.delete('acme', 'example')
+u.delete('acme', 'example_wildcard')
+
+for section in u.get_all('acme'):
+    if u.get('acme', section) == 'acme':
+        nsmigration.vprint("Setting acme mail")
+        u.set('acme', section, 'account_email', data['config']['account_email'])
+
+u.set('acme', 'ns_default', 'cert')
+u.set('acme', 'ns_default', 'enabled', '1')
+u.set('acme', 'ns_default', 'use_staging', '0')
+u.set('acme', 'ns_default', 'keylength', '2048')
+u.set('acme', 'ns_default', 'update_nginx', '1')
+nsmigration.vprint("Setting acme domains")
+u.set('acme', 'ns_default', 'domains', data['config']['domains'])
+
+# Save configuration
+u.commit('acme')

--- a/packages/ns-migration/files/scripts/reverse_proxy
+++ b/packages/ns-migration/files/scripts/reverse_proxy
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import sys
+import nsmigration
+from nextsec import utils
+
+(u, data, nmap) = nsmigration.init("reverse_proxy.json")
+
+if 'server' not in data and 'locations' not in data:
+    sys.exit(0)
+
+# handle reverse proxy paths for main virtual host
+lcount = len(data['locations'])
+if lcount > 0:
+    # enable reverse proxy for default _lan server
+    includes = list(u.get('nginx', '_lan', 'include', list=True, default=list()))
+    if 'conf.d/_lan.proxy' not in includes:
+        includes.append('conf.d/_lan.proxy')
+    u.set('nginx', '_lan', 'include', includes)
+for location in data['locations']:
+    loc = utils.get_id(f'location{lcount}')
+    nsmigration.vprint(f'Setting reverse proxy location {loc}') 
+    u.set('nginx', loc, 'location')
+    u.set('nginx', loc, 'uci_server', '_lan')
+    for o in location:
+        u.set('nginx', loc, o, location[o])
+    lcount = lcount-1
+
+# handle host-bases reverse proxy
+scount = len(data['servers'])
+for server in data['servers']:
+    s = utils.get_id(f'server{scount}')
+    u.set('nginx', s, 'server')
+    locations = server.pop('locations')
+    crt = server.pop('ssl_certificate')
+    with open(f'/etc/nginx/conf.d/{s}.crt', 'w') as fp:
+        fp.write(crt)
+    u.set('nginx', s, 'ssl_certificate', f'/etc/nginx/conf.d/{s}.crt')
+    key = server.pop('ssl_certificate_key')
+    with open(f'/etc/nginx/conf.d/{s}.key', 'w') as fp:
+        fp.write(key)
+    u.set('nginx', s, 'ssl_certificate_key', f'/etc/nginx/conf.d/{s}.key')
+    nsmigration.vprint(f'Setting reverse proxy host {s}')
+    u.set('nginx', s, 'uci_description', server.pop('description'))
+    for o in server:
+        u.set('nginx', s, o, server[o])
+
+    lcount = len(locations)
+    if lcount > 0:
+        # enable reverse proxy for the server
+        u.set('nginx', s, 'include', [f'conf.d/{s}.proxy'])
+    for location in locations:
+        loc = utils.get_id(f'server{scount}_location{lcount}')
+        u.set('nginx', loc, 'location')
+        u.set('nginx', loc, 'uci_server', s)
+        for o in location:
+            u.set('nginx', loc, o, location[o])
+
+        lcount = lcount-1
+
+    scount = scount-1
+
+# Save configuration
+u.commit('nginx')

--- a/packages/ns-reverse-proxy/Makefile
+++ b/packages/ns-reverse-proxy/Makefile
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include $(TOPDIR)/rules.mk
+ 
+PKG_NAME:=ns-reverse-proxy
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=$(AUTORELEASE)
+ 
+PKG_BUILD_DIR:=$(BUILD_DIR)/ns-reverse-proxy-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
+PKG_LICENSE:=GPL-3.0-only
+
+include $(INCLUDE_DIR)/package.mk
+ 
+define Package/ns-reverse-proxy
+	SECTION:=base
+	CATEGORY:=NextSecurity
+	TITLE:=NextSecurity reverse-proxy manager
+	URL:=https://github.com/NethServer/nextsecurity/
+	DEPENDS:=+nginx
+	PKGARCH:=all
+endef
+ 
+define Package/ns-reverse-proxy/description
+	Manage reverse-proxy
+endef
+
+# this is required, otherwise compile will fail
+define Build/Compile
+endef
+
+define Package/ns-reverse-proxy/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/nginx-proxy $(1)/usr/sbin
+endef
+ 
+$(eval $(call BuildPackage,ns-reverse-proxy))

--- a/packages/ns-reverse-proxy/README.md
+++ b/packages/ns-reverse-proxy/README.md
@@ -1,0 +1,98 @@
+# ns-reverse-proxy
+
+Use nginx to act as a reverse proxy.
+The reverse proxy forwards web requests to another HTTP server and serves responses in behalf of it. 
+
+The reverse proxy supports the following rules:
+
+- path based: matches the given path when requested to the default virtual host (`_lan`)
+- host based: matches the given host name
+
+## Configuration
+
+This package introduces a new object of type `location` inside UCI config `/etc/config/nginx`.
+
+The `location` object can contain any `nginx` directive, plus the following special options:
+
+- `location`: URI of the location, it accepts [nginx syntax](http://nginx.org/en/docs/http/ngx_http_core_module.html#location)
+- `uci_server`: it binds the location to a `server` object with the same name; if set to `_lan`,  the location will be added inside the default virtual host
+- `description`: (optional) description of the rule, it's converted to a comment inside the configuration file
+- `allow`: (optional) an array of allowed IP addresses; if present, all other addresses will be automatically denied
+
+If a directive can be used multiple times, it's represented as a UCI list.
+
+The `nginx-proxy` utility reads all the location objects from UCI config and creates the nginx configuration
+inside `/etc/nginx/conf.d/<server>.proxy` files, like `/etc/nginx/conf.d/_lan.proxy`.
+Then, the generated files must be explicitly added to the `include` option of the server object.
+
+### Path rules
+
+Example of a path rule for the default virtual host:
+```
+config location 'ns_location1'
+	option uci_server '_lan'
+	option proxy_pass 'https://192.168.100.234'
+	option description 'Reverse proxy with path'
+	option proxy_ssl_verify 'off'
+	option location '/test'
+```
+
+To enable the rule:
+```
+nginx-proxy
+uci add_list nginx._lan.include='conf.d/_lan.proxy'
+uci commit nginx
+/etc/init.d/nginx restart
+```
+
+Example of a path rule for a WebSocket inside the `ns_server2` virtual host:
+```
+config location 'ns_server2_location1'
+	option uci_server 'ns_server2'
+	option location '/ws'
+	option proxy_pass 'http://192.168.0.100/ws'
+	option proxy_http_version '1.1'
+	list proxy_set_header 'Upgrade $http_upgrade'
+	list proxy_set_header 'Connection "Upgrade"'
+``` 
+
+To enable the rule:
+```
+nginx-proxy
+uci add_list nginx.ns_server2.include='conf.d/ns_server2.proxy'
+uci commit nginx
+/etc/init.d/nginx restart
+```
+
+### Host rules
+
+Host rules use host configuration from [official OpenWrt documentation for nginx](https://openwrt.org/docs/guide-user/services/webserver/nginx).
+Each host must include it's `.proxy` configuration file containing the locations.
+
+Example for host `test.example.org`:
+```
+config location 'ns_server1_location2'
+	option uci_server 'ns_server1'
+	option location '/'
+	option proxy_pass 'http://192.168.100.200'
+
+config server 'ns_server1'
+	option ssl_certificate '/etc/nginx/conf.d/ns_server1.crt'
+	option ssl_certificate_key '/etc/nginx/conf.d/ns_server1.key'
+	option uci_description 'Proxy pass host'
+	option ssl_session_timeout '64m'
+	option ssl_session_cache 'shared:SSL:32k'
+	option proxy_ssl_verify 'on'
+	option server_name 'test.example.org'
+	list proxy_set_header 'Host $http_host'
+	list listen '443 ssl'
+	list listen '[::]:443 ssl'
+	list allow '192.168.100.0/24'
+    list include 'conf.d/ns_server1.proxy'
+```
+
+To enable the rule:
+```
+nginx-proxy
+/etc/init.d/nginx restart
+```

--- a/packages/ns-reverse-proxy/files/nginx-proxy
+++ b/packages/ns-reverse-proxy/files/nginx-proxy
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import os
+import sys
+from glob import glob
+from euci import EUci
+
+u = EUci()
+
+def write_locations(locations, fpath):
+    with open(fpath, 'w') as fp:
+        for location in locations:
+            path = location.pop('location')
+            desc = location.pop('description', '')
+            if desc:
+                fp.write('# %s\n' % desc)
+            fp.write('location %s {\n' % path)
+            for o in location:
+                # check if option is an array
+                if hasattr(location[o], '__len__') and (not isinstance(location[o], str)):
+                    for i in location[o]:
+                        fp.write('  %s %s;\n' % (o, i))
+                else:
+                    fp.write('  %s %s;\n' % (o, location[o]))
+                if o == 'allow':
+                    fp.write('  deny all;\n')
+
+            fp.write('}\n')
+
+# cleanup existing configuration
+for pfile in glob('/etc/nginx/conf.d/*.proxy'):
+    os.unlink(pfile)
+
+servers = dict()
+
+# generate ns_locations files
+for section in u.get_all('nginx'):
+    if u.get('nginx', section) != 'location':
+        continue
+
+    location = u.get_all('nginx', section)
+    server = location.pop('uci_server')
+    if server not in servers:
+        servers[server] = list()
+    servers[server].append(location)
+
+for server in servers:
+    write_locations(servers[server], f'/etc/nginx/conf.d/{server}.proxy')


### PR DESCRIPTION
- [x] Implement reverse proxy
- [x] Add Let's Encrypt client
   - [x] Support Digital Ocean virtual machines (this is required to easily have a virtual machine with a public IP)

See also https://github.com/NethServer/nethserver-firewall-migration/pull/9