### PR TITLE
Threat shield startup fixes

### DIFF
--- a/packages/ns-threat_shield/Makefile
+++ b/packages/ns-threat_shield/Makefile
@@ -43,7 +43,7 @@ define Package/ns-threat_shield/install
 	$(INSTALL_BIN) ./files/ts-ip $(1)/usr/sbin/ts-ip
 	$(INSTALL_BIN) ./files/ts-ip-download $(1)/usr/sbin/ts-ip-download
 	$(INSTALL_BIN) ./files/ts-ip-nft $(1)/usr/sbin/ts-ip-nft
-	$(INSTALL_CONF) ./files/20_threat_shield $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/20_threat_shield $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/usr/share/threat_shield
 	$(INSTALL_DATA) ./files/nethesis-ip.sources $(1)/usr/share/threat_shield
 	$(INSTALL_DATA) ./files/nethesis-dns.sources $(1)/usr/share/threat_shield
@@ -54,10 +54,9 @@ endef
 define Package/ns-threat_shield/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  crontab -l | grep -q '/usr/sbin/ts-ip' || echo '*/50 * * * * sleep $$(( RANDOM % 3500 )); /usr/sbin/ts-ip' >> /etc/crontabs/root
-  crontab -l | grep -q '/etc/init.d/ts-dns' || echo '1 */12 * * * sleep $$(( RANDOM % 3600 )); /etc/init.d/ts-dns reload' >> /etc/crontabs/root
+  (. /etc/uci-defaults/20_threat_shield)
+  rm -f /etc/uci-defaults/20_threat_shield
   /etc/init.d/cron restart
-  /etc/init.d/ts-ip enable
 fi
 exit 0
 endef
@@ -68,7 +67,7 @@ if [ -z "$${IPKG_INSTROOT}" ]; then
     uci set threat_shield.config.status=0
 	uci commit
 	/usr/sbin/ts-ip
-	crontab -l | grep -v "/usr/sbin/ts-ip" | sort | uniq | crontab -
+	crontab -l | grep -v "/etc/init.d/ts-ip" | sort | uniq | crontab -
 	crontab -l | grep -v "/etc/init.d/ts-dns" | sort | uniq | crontab -
 fi
 exit 0

--- a/packages/ns-threat_shield/files/20_threat_shield
+++ b/packages/ns-threat_shield/files/20_threat_shield
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+crontab -l | grep -q '/etc/init.d/ts-ip' || echo '50 * * * * sleep $(( RANDOM % 3500 )); /etc/init.d/ts-ip reload' >> /etc/crontabs/root
+crontab -l | grep -q '/etc/init.d/ts-dns' || echo '1 */12 * * * sleep $(( RANDOM % 3600 )); /etc/init.d/ts-dns reload' >> /etc/crontabs/root
+
 [ "$(uci -q get threat_shield.config.status)" != "" ] && exit 0
 
 uci -q import threat_shield << EOI

--- a/packages/ns-threat_shield/files/ts-dns.init
+++ b/packages/ns-threat_shield/files/ts-dns.init
@@ -9,15 +9,10 @@
 # Threat shield DNS: add Nethesis categories to adblock
 #
 
+START=30
 DEST_DIR=/var/ts-dns/
 NETHESIS_SOURCES=/usr/share/threat_shield/nethesis-dns.sources.gz
 ADBLOCK_SOURCES=/etc/adblock/adblock.sources.gz
-
-STATUS=$(uci -q get adblock.global.adb_enabled)
-
-if [ "$STATUS" != '1' ]; then
-    exit 0
-fi
 
 SYSTEM_ID=$(uci -q get ns-plug.config.system_id)
 SYSTEM_SECRET=$(uci -q get ns-plug.config.secret)

--- a/packages/ns-threat_shield/files/ts-ip.init
+++ b/packages/ns-threat_shield/files/ts-ip.init
@@ -5,8 +5,28 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
+# start after network and dns
 START=20
 
-start() {
-    /usr/sbin/ts-ip
+USE_PROCD=1
+
+start_service()
+{
+	procd_open_instance "ts-ip"
+	procd_set_param command "/usr/sbin/ts-ip"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+stop_service()
+{
+# Cleanup existing table
+	if nft list tables inet | grep -q 'table inet threat_shield'; then
+		nft delete table inet threat_shield
+	fi
+}
+
+service_triggers() {
+	procd_add_reload_trigger threat_shield
 }


### PR DESCRIPTION
Enable both Threat Shield services (ts-ip and ts-dns) using the standard START init variable.
Add cronjobs via uci-default.
Use procd for ts-ip init script to have a trigger to reload service on configuration change and a useful option to temporarily stop it without disabling the service.

This pull request replaces https://github.com/NethServer/nextsecurity/pull/47