### PR TITLE
conf: add debug tool whois

### DIFF
--- a/config/debugtools.conf
+++ b/config/debugtools.conf
@@ -29,3 +29,5 @@ CONFIG_PACKAGE_bind-libs=y
 CONFIG_PACKAGE_libuv=y
 CONFIG_PACKAGE_bind-dig=y
 CONFIG_BIND_ENABLE_DOH=y
+# whois
+CONFIG_PACKAGE_whois=y


### PR DESCRIPTION
The command is usefull to check public IPs info especially when such IPs are blocked by filters