### PR TITLE
ns-migration: log to file

### DIFF
--- a/files/etc/uci-defaults/95-nextsec-migrate
+++ b/files/etc/uci-defaults/95-nextsec-migrate
@@ -1,6 +1,6 @@
 archive="/usr/share/migration/export.tar.gz"
 if [ -f "${archive}" ]; then
-    /usr/sbin/ns-import $archive | tee /dev/kmsg
+    /usr/sbin/ns-import $archive | tee /var/log/migration.log
 
     if [ $? -eq 0 ]; then
         mv "${archive}" "${archive}.done"

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -38,6 +38,9 @@ tar xvzf export.tar.gz
 
 The `ns-import` script is verbose by default, use the `-q` option to suppress output to standard output.
 
+On first boot, if a file named `/usr/share/migration/export.tar.gz` is present, the system
+will automatically import the configuration. Migration output will be logged to `/var/log/migration.log`.
+
 ### Remapping interfaces
 
 When importing the configuration from an old machine to a new one, you need to remap
@@ -316,9 +319,6 @@ The following NS7 options will not be migrated:
 - `UpdateInterval`
 
 ## Other features
-
-The following features will be migrated in the upcoming months:
-
 
 The following features are not migrated to NextSecurity:
 


### PR DESCRIPTION
Since the migration process is started before any logger is active, log all output to a log file