### PR TITLE
packages: add ns-phonehome

### DIFF
--- a/config/ns-phonehome.conf
+++ b/config/ns-phonehome.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_ns-phonehome=y

--- a/packages/ns-phonehome/Makefile
+++ b/packages/ns-phonehome/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include $(TOPDIR)/rules.mk
+ 
+PKG_NAME:=ns-phonehome
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=$(AUTORELEASE)
+ 
+PKG_BUILD_DIR:=$(BUILD_DIR)/ns-phonehome-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
+PKG_LICENSE:=GPL-3.0-only
+
+include $(INCLUDE_DIR)/package.mk
+ 
+define Package/ns-phonehome
+	SECTION:=base
+	CATEGORY:=NextSecurity
+	TITLE:=NextSecurity controller client
+	URL:=https://github.com/NethServer/nextsecurity-controller/
+	DEPENDS:=+lscpu +dmidecode +pciutils +python3-uuid
+	PKGARCH:=all
+endef
+ 
+define Package/ns-phonehome/description
+	Send statistical data to remote server
+endef
+
+define Package/ns-phonehome/conffiles
+	/etc/config/phonehome
+endef
+
+# this is required, otherwise compile will fail
+define Build/Compile
+endef
+
+define Package/ns-phonehome/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+  (. /etc/uci-defaults/20_ns-phonehome)
+  rm -f /etc/uci-defaults/20_ns-phonehome
+  /etc/init.d/cron restart
+fi
+exit 0
+endef
+
+define Package/ns-phonehome/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+  crontab -l | grep -v "/usr/sbin/send-phonehome" | sort | uniq | crontab -
+fi
+exit 0
+endef
+
+define Package/ns-phonehome/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/phonehome $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/send-phonehome $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/20_ns-phonehome $(1)/etc/uci-defaults
+	$(INSTALL_CONF) ./files/config $(1)/etc/config/phonehome
+endef
+ 
+$(eval $(call BuildPackage,ns-phonehome))

--- a/packages/ns-phonehome/README.md
+++ b/packages/ns-phonehome/README.md
@@ -12,6 +12,6 @@ phonehome | jq
 
 To disable the phonehome:
 ```
-uci set phonehome.config.enabled=1
+uci set phonehome.config.enabled=0
 uci commit phonehome
 ```

--- a/packages/ns-phonehome/README.md
+++ b/packages/ns-phonehome/README.md
@@ -1,0 +1,17 @@
+# ns-phonehome
+
+The phonehome sends every night some statistical data to a remote server.
+These data are used to:
+- create an installation map [https://phonehome.nethserver.org/](https://phonehome.nethserver.org/)
+- create an inventory of hardware compatibile with NextSecurity
+
+Sent data can be inspected using the following command:
+```
+phonehome | jq
+```
+
+To disable the phonehome:
+```
+uci set phonehome.config.enabled=1
+uci commit phonehome
+```

--- a/packages/ns-phonehome/files/20_ns-phonehome
+++ b/packages/ns-phonehome/files/20_ns-phonehome
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+crontab -l | grep -q '/usr/sbin/send-heartbeat' || echo '10 4 * * * sleep $(( RANDOM % 1800 )); /usr/sbin/send-phonehome' >> /etc/crontabs/root

--- a/packages/ns-phonehome/files/20_ns-phonehome
+++ b/packages/ns-phonehome/files/20_ns-phonehome
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-crontab -l | grep -q '/usr/sbin/send-heartbeat' || echo '10 4 * * * sleep $(( RANDOM % 1800 )); /usr/sbin/send-phonehome' >> /etc/crontabs/root
+crontab -l | grep -q '/usr/sbin/send-phonehome' || echo '10 4 * * * sleep $(( RANDOM % 1800 )); /usr/sbin/send-phonehome' >> /etc/crontabs/root

--- a/packages/ns-phonehome/files/config
+++ b/packages/ns-phonehome/files/config
@@ -1,0 +1,3 @@
+config main 'config'
+    option enabled '1'
+    option url 'https://phonehome.nethserver.org/api/installation'

--- a/packages/ns-phonehome/files/phonehome
+++ b/packages/ns-phonehome/files/phonehome
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import csv
+import json
+import uuid
+import subprocess
+from euci import EUci
+
+def _run(cmd):
+    try:
+        proc = subprocess.run(cmd, shell=True, check=True, capture_output=True, text=True)
+        return proc.stdout.rstrip().lstrip()
+    except:
+        return ''
+
+def _get_cpu_field(field, cpu_info):
+    for f in cpu_info:
+        if f['field'].startswith(field):
+            return f['data']
+
+    return ''
+
+cpu_info = json.loads(_run('lscpu -J'))['lscpu']
+
+# map kernel driver to device id
+drivers = {}
+for line in _run("find /sys | grep '.*/drivers/.*/0000:.*$' | cut -d'/' -f6,7").split('\n'):
+    try:
+        (driver,bus) = line.split("/0000:")
+        drivers[bus] = driver
+    except:
+        continue
+
+# lspci -n: 00:1b.0 0403: 8086:293e (rev 03)
+# fields:   bus class vendor:device revision
+pci = {}
+for line in _run("lspci -n").split("\n"):
+    revision = ''
+    fields = line.split(" ", maxsplit=4)
+    (vendor, device) = fields[2].split(":")
+    if len(fields) > 3:
+        revision = fields[4]
+    pci[fields[0]] = {"class_id": fields[1].rstrip(":"), "vendor_id": vendor, "device_id": device, "revision": revision.strip(')')}
+
+# lspci -mm: 00:00.0 "Host bridge" "Intel Corporation" "82G33/G31/P35/P31 Express DRAM Controller" -p00 "Red Hat, Inc." "QEMU Virtual Machine"
+for fields in csv.reader(_run("lspci -mm").split("\n"), delimiter=' ', quotechar='"'):
+    pci[fields[0]]['class_name'] = fields[1].strip('"')
+    pci[fields[0]]['vendor_name'] = fields[2]
+    pci[fields[0]]['device_name'] = fields[3]
+    pci[fields[0]]['driver'] =  drivers.get(fields[0], '')
+
+# use hardware uuid, if not present just generate one
+sid = _run("cat /sys/class/dmi/id/product_uuid")
+if not sid:
+    u = EUci()
+    sid = u.get('phonehome', 'config', 'uuid', default=None)
+    if not sid:
+        sid = str(uuid.uuid4())
+        u.set('phonehome', 'config', 'uuid', sid)
+        u.commit('phonehome')
+
+data = {
+    "uuid": sid,
+    "installation": "nextsecurity",
+    "facts": {
+        "distro": {
+            "name": "NextSecurity",
+            "version": _run('grep VERSION= /etc/os-release | cut -d= -f 2 | tr -d \'"\'')
+        },
+        "processors": { 
+            "count": _run("grep processor /proc/cpuinfo  | wc -l"), 
+            "model":  _get_cpu_field("Model name", cpu_info),
+            "architecture": _get_cpu_field("Architecture", cpu_info)
+        },
+        "product": {
+            "name": _run("dmidecode -t 2 | grep 'Product Name' | awk -F: '{print $2}'"),
+            "manufacturer":  _run("dmidecode -t 2 | grep 'Manufacturer' | awk -F: '{print $2}'")
+        },
+        "virtual": _get_cpu_field("Hypervisor vendor", cpu_info) if _get_cpu_field("Hypervisor vendor", cpu_info) else 'physical',
+        "memory": {
+            "swap": { "used_bytes": _run("free | grep 'Swap': | awk '{print $3}'"), "available_bytes": _run("free | grep 'Swap': | awk '{print $7}'") },
+            "system": { "used_bytes": _run("free | grep 'Mem': | awk '{print $3}'"), "available_bytes": _run("free | grep 'Mem:' | awk '{print $7}'") }
+        },
+        "pci": list(pci.values()),
+        "version": "1.0.0"
+    }
+}
+print(json.dumps(data))

--- a/packages/ns-phonehome/files/send-phonehome
+++ b/packages/ns-phonehome/files/send-phonehome
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# Send the phonehome data
+
+ENABLED=$(uci -q get phonehome.config.enabled)
+URL=$(uci -q get phonehome.config.url)
+
+if [ "$ENABLED" = "0" ] || [ -z "$URL" ]; then
+    exit 0
+fi
+
+/usr/sbin/phonehome | curl -m 180 --retry 3 -L -s \
+	-H "Content-type: application/json" -H "Accept: application/json" \
+	--data-binary @- "$URL" > /dev/null


### PR DESCRIPTION
Send statistical data to remote server.

The phonehome output can be used to create a database of all working hardware.
To list the PCI interfaces with relevant kernel module use:
```
phonehome | jq .facts.pci
```