### PR TITLE
ns-openvpn: fix db initialization

### DIFF
--- a/packages/ns-openvpn/Makefile
+++ b/packages/ns-openvpn/Makefile
@@ -37,7 +37,7 @@ define Package/ns-openvpn/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/usr/libexec/ns-openvpn/connect-scripts
 	$(INSTALL_DIR) $(1)/usr/libexec/ns-openvpn/disconnect-scripts
-
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/ns-openvpnrw-setup $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/ns-openvpnrw-add $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/ns-openvpnrw-init-pki $(1)/usr/sbin
@@ -53,13 +53,14 @@ define Package/ns-openvpn/install
 	$(INSTALL_BIN) ./files/10-tunnel-iroute $(1)/usr/libexec/ns-openvpn/connect-scripts
 	$(INSTALL_BIN) ./files/80-save-connection $(1)/usr/libexec/ns-openvpn/connect-scripts
 	$(INSTALL_BIN) ./files/80-save-disconnection $(1)/usr/libexec/ns-openvpn/disconnect-scripts
+	$(INSTALL_BIN) ./files/99_ns-openvpn $(1)/etc/uci-defaults
 endef
 
 define Package/ns-openvpn/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  grep '/usr/libexec/ns-openvpn/init-connections-db' /etc/openvpn.user || echo "/usr/libexec/ns-openvpn/init-connections-db" >> /etc/openvpn.user
-  /usr/sbin/ns-openvpnrw-setup
+  (. /etc/uci-defaults/20_ns-openvpn)
+  rm -f /etc/uci-defaults/20_ns-openvpn
 fi
 exit 0
 endef

--- a/packages/ns-openvpn/files/99_ns-openvpn
+++ b/packages/ns-openvpn/files/99_ns-openvpn
@@ -1,2 +1,11 @@
 grep -q '/usr/libexec/ns-openvpn/init-connections-db' /etc/openvpn.user || echo "/usr/libexec/ns-openvpn/init-connections-db" >> /etc/openvpn.user
-/usr/sbin/ns-openvpnrw-setup
+# start openvpn initialization when firewall is ready
+# the temporary init script will be executed only once
+cat << EOF > /etc/rc.d/S99ns-openvpn-init
+#!/bin/sh
+/usr/sbin/ns-openvpnrw-setup 2>&1 | tee /var/log/ns-openvpnrw-setup.log
+if [ \$? -eq 0 ]; then
+    rm -f /etc/rc.d/S99ns-openvpn-init
+fi
+EOF
+chmod a+x /etc/rc.d/S99ns-openvpn-init

--- a/packages/ns-openvpn/files/99_ns-openvpn
+++ b/packages/ns-openvpn/files/99_ns-openvpn
@@ -1,0 +1,2 @@
+grep -q '/usr/libexec/ns-openvpn/init-connections-db' /etc/openvpn.user || echo "/usr/libexec/ns-openvpn/init-connections-db" >> /etc/openvpn.user
+/usr/sbin/ns-openvpnrw-setup

--- a/packages/ns-openvpn/files/ns-openvpnrw-setup
+++ b/packages/ns-openvpn/files/ns-openvpnrw-setup
@@ -42,5 +42,5 @@ except:
     u.set('openvpn', instance, 'key', f'/etc/openvpn/{instance}/pki/private/server.key')
     u.commit('openvpn')
 
-    # initialize firewall rules
+    # initialize pki
     subprocess.run(["/usr/sbin/ns-openvpnrw-init-pki", instance])


### PR DESCRIPTION
If the package is already present inside the image, the postinst script is not executed.
The db initialization has been moved under uci-defaults which are executed at first boot