### PR TITLE
Added missing $schema to phonehome request

### DIFF
--- a/packages/ns-phonehome/files/phonehome
+++ b/packages/ns-phonehome/files/phonehome
@@ -65,6 +65,7 @@ if not sid:
         u.commit('phonehome')
 
 data = {
+    "$schema": "https://schema.nethserver.org/facts/2022-12.json",
     "uuid": sid,
     "installation": "nextsecurity",
     "facts": {


### PR DESCRIPTION
Sorry to bother, while future-proofing the new phonehome, the need to reference the validation schema arised. You can find an up-to-date doc of the schema [here](https://github.com/NethServer/phonehome-server/blob/master/resources/validation/facts/2022-12.json). The request made is still valid, no additional changes are required.
