### PR TITLE
patches: change nginx large_client_header_buffers

### DIFF
--- a/patches/feeds/packages/100-nginx-buffer.patch
+++ b/patches/feeds/packages/100-nginx-buffer.patch
@@ -1,0 +1,12 @@
+diff --git a/net/nginx-util/files/uci.conf.template b/net/nginx-util/files/uci.conf.template
+index 1c611d9ad..54b85b3ed 100644
+--- a/net/nginx-util/files/uci.conf.template
++++ b/net/nginx-util/files/uci.conf.template
+@@ -19,7 +19,6 @@ http {
+ 	sendfile on;
+ 
+ 	client_max_body_size 128M;
+-	large_client_header_buffers 2 1k;
+ 
+ 	gzip on;
+ 	gzip_vary on;


### PR DESCRIPTION
Restore nginx large_client_header_buffers default to "4 8k". OpenWrt default are too small for many sites when nginx is used as reverse proxy