### PR TITLE
ns-migration: drop ipset for redirects

### DIFF
--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -126,6 +126,10 @@ The `redirect` script will import:
 
 If `HairpinNat` option was enabled on NS7, all imported port forward will have hairpin enabled (see `reflection` option).
 
+Differences since NS7:
+
+- port forwards with multiple IP limitations will be split into multiple redirects
+
 ## Firewall rules
 
 The `rules` script will import:

--- a/packages/ns-migration/files/scripts/redirects
+++ b/packages/ns-migration/files/scripts/redirects
@@ -15,23 +15,11 @@ for pf in data['redirects']:
     name = pf.pop("key")
     pfname = utils.get_id(name)
     desc = pf.pop("description")
-    # create ipset, if needed
-    if 'src_ip' in pf and pf['src_ip']:
-        sname = utils.get_id(f"{name}_ipset")
-        nsmigration.vprint(f'Creating ipset {sname} for port forward {pfname}')
-        u.set("firewall", sname, "ipset")
-        u.set("firewall", sname, "name", sname)
-        u.set("firewall", sname, "match", "src_net")
-        u.set("firewall", sname, "enabled", "1")
-        u.set("firewall", sname, "entry", pf.pop("src_ip"))
     # create port forward 
     nsmigration.vprint(f'Creating port forward {pfname}')
     u.set("firewall", pfname, "redirect")
     u.set("firewall", pfname, "name", desc)
     u.set("firewall", pfname, "src", 'wan')
-    # limit pf access, if needed
-    if sname:
-        u.set("firewall", pfname, "ipset", f"{sname}")
     # this should be irrelevant for DNAT, but it prevents a warning
     u.set("firewall", pfname, "dest", "lan")
     for o in pf:


### PR DESCRIPTION
Luci doesn't handle redirects with ipset limitations

See also https://github.com/NethServer/nethserver-firewall-migration/pull/13