### PR TITLE
ns-openvpn: execute setup on first boot and on upgrade

### DIFF
--- a/packages/ns-openvpn/README.md
+++ b/packages/ns-openvpn/README.md
@@ -44,7 +44,6 @@ Each script takes 2 arguments: the server instance name and the client CN.
 
 Execute:
 ```
-ns-openvpnrw-setup
 uci set openvpn.ns_roadwarrior.enabled=1
 uci commit openvpn
 service openvpn start

--- a/packages/ns-openvpn/files/99_ns-openvpn
+++ b/packages/ns-openvpn/files/99_ns-openvpn
@@ -1,11 +1,2 @@
 grep -q '/usr/libexec/ns-openvpn/init-connections-db' /etc/openvpn.user || echo "/usr/libexec/ns-openvpn/init-connections-db" >> /etc/openvpn.user
-# start openvpn initialization when firewall is ready
-# the temporary init script will be executed only once
-cat << EOF > /etc/rc.d/S99ns-openvpn-init
-#!/bin/sh
-/usr/sbin/ns-openvpnrw-setup 2>&1 | tee /var/log/ns-openvpnrw-setup.log
-if [ \$? -eq 0 ]; then
-    rm -f /etc/rc.d/S99ns-openvpn-init
-fi
-EOF
-chmod a+x /etc/rc.d/S99ns-openvpn-init
+/usr/sbin/ns-openvpnrw-setup

--- a/packages/ns-openvpn/files/ns-openvpnrw-setup
+++ b/packages/ns-openvpn/files/ns-openvpnrw-setup
@@ -5,9 +5,16 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
+import os
+import sys
 import subprocess
 from euci import EUci
 from nextsec import firewall, utils
+
+instance = utils.get_id('roadwarrior')
+# Make sure to not change firewall rule on upgrade
+if os.path.isdir(f'/etc/openvpn/{instance}'):
+    sys.exit(0)
 
 u = EUci()
 firewall.add_to_lan(u, 'tunrw')
@@ -16,7 +23,6 @@ ovpn_zone = firewall.add_trusted_zone(u, "openvpnrw", [ovpn_interface])
 firewall.add_service(u, 'openvpnrw', '1194', 'udp')
 u.commit('firewall')
 
-instance = utils.get_id('roadwarrior')
 try:
     u.get('openvpn', instance)
 except:

--- a/packages/ns-openvpn/files/ns-openvpnrw-setup
+++ b/packages/ns-openvpn/files/ns-openvpnrw-setup
@@ -14,7 +14,7 @@ firewall.add_to_lan(u, 'tunrw')
 ovpn_interface = firewall.add_vpn_interface(u, 'openvpnrw', 'tunrw')
 ovpn_zone = firewall.add_trusted_zone(u, "openvpnrw", [ovpn_interface])
 firewall.add_service(u, 'openvpnrw', '1194', 'udp')
-firewall.apply(u)
+u.commit('firewall')
 
 instance = utils.get_id('roadwarrior')
 try:


### PR DESCRIPTION
PKI initialization should be fast enouth with 'dsaparm' option for 'openssl dhparam'  command.

Other changes: do not recreate `allow-openvpnrw` rule across update to avoid overwriting user firewall setup