### PR TITLE
files: add persistent keymap configuration

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -156,7 +156,18 @@ Then will be able to login to the console using default credentials above.
 
 Please note that the system is configured with `US` keyboard layout.
 
-To change current keyboard layout, execute the `menu` script and select option `1`.
+To temporary change current keyboard layout to Italian, login to the system then execute:
+```
+loadkmap < /usr/share/keymaps/it.map.bin
+```
+
+Keyboard layout configuration can be saved by writing the keymap code inside `/etc/keymap`. Example:
+```
+echo 'it' > /etc/keymap
+grep -q /etc/keymap /etc/sysupgrade.conf || echo /etc/keymap >> /etc/sysupgrade.conf
+```
+
+To obtain the list of availabile keymaps execute: `ls -1 /usr/share/keymaps/ | cut -d'.' -f1`.
 
 Other keymaps can be generated from a CentOS machine with the following command:
 ```

--- a/files/usr/libexec/login.sh
+++ b/files/usr/libexec/login.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+[ "$(uci -q get system.@system[0].ttylogin)" = 1 ] || exec /bin/ash --login
+
+[ -f /etc/keymap ] && /sbin/loadkmap < /usr/share/keymaps/$(/bin/cat /etc/keymap).map.bin 2>/dev/null
+
+exec /bin/login


### PR DESCRIPTION
Since the menu is gone, this is and easy way to make sure keymap is already configured before login.

Replaces #100 