### PR TITLE
ns-storage: fix logrotate cronjob

### DIFF
--- a/packages/ns-storage/Makefile
+++ b/packages/ns-storage/Makefile
@@ -36,7 +36,7 @@ endef
 define Package/ns-storage/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  crontab -l | grep -q '/usr/sbin/logrotate' || echo '5 1 * * * /usr/sbin/logrotate' >> /etc/crontabs/root
+  crontab -l | grep -q '/usr/sbin/logrotate /etc/logrotate.conf' || echo '5 1 * * * /usr/sbin/logrotate /etc/logrotate.conf' >> /etc/crontabs/root
   /etc/init.d/cron restart
 fi
 exit 0
@@ -45,7 +45,7 @@ endef
 define Package/ns-storage/prerm
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-	crontab -l | grep -v "/usr/sbin/logrotate" | sort | uniq | crontab -
+	crontab -l | grep -v "/usr/sbin/logrotate /etc/logrotate.conf" | sort | uniq | crontab -
 fi
 exit 0
 endef

--- a/packages/ns-storage/files/30_ns-storage
+++ b/packages/ns-storage/files/30_ns-storage
@@ -20,4 +20,4 @@ config selector ns_memory
 	option destination ':omfile:\$log_rotation'
 EOI
 
-crontab -l | grep -q '/usr/sbin/logrotate' || echo '5 1 * * * /usr/sbin/logrotate' >> /etc/crontabs/root
+crontab -l | grep -q '/usr/sbin/logrotate /etc/logrotate.conf' || echo '5 1 * * * /usr/sbin/logrotate  /etc/logrotate.conf' >> /etc/crontabs/root


### PR DESCRIPTION
Logorate requires the path of configuration file as first parameter.

When executing logrotate from command line:
```
# logrotate 
logrotate 3.17.0 - Copyright (C) 1995-2001 Red Hat, Inc.
This may be freely redistributed under the terms of the GNU General Public License

Usage: logrotate [-dfv?] [-d|--debug] [-f|--force] [-m|--mail=command] [-s|--state=statefile] [--skip-state-lock] [-v|--verbose] [-l|--log=logfile] [--version]
        [-?|--help] [--usage] [OPTION...] <configfile>

```

See also cron job script from `logrotate-3.8.6-19.el7.x86_64` RPM on CentOS 7:
```bash
# cat /etc/cron.daily/logrotate
#!/bin/sh

/usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.conf
EXITVALUE=$?
if [ $EXITVALUE != 0 ]; then
    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
fi
exit 0
```