### PR TITLE
packages. ns-dedalo: move from timezone to zonename in engine

### DIFF
--- a/packages/ns-dedalo/patches/002-template-engine.patch
+++ b/packages/ns-dedalo/patches/002-template-engine.patch
@@ -7,7 +7,7 @@ Index: ns-dedalo-0.0.1/dedalo/template/engine
  HS_DIGEST=$(echo -n "$HS_SECRET$HS_UUID" | md5sum | awk '{print $1}')
  HS_AAA_HOST=$(echo "$HS_AAA_URL" | sed -e 's|https\?://\([^/:]\+\)\(.*\)|\1|')
 -HS_TIMEZONE=$(timedatectl | grep "Time zone" | awk '{print $3}')
-+HS_TIMEZONE=$(/sbin/uci get system.@system[0].timezone)
++HS_TIMEZONE=$(/sbin/uci get system.@system[0].zonename)
  HS_WALLED_GARDEN_INTEGRATIONS=$(find /opt/icaro/dedalo/walled_gardens/integrations/ -type f -exec echo include {} \;)
  
  eval "cat <<EOF


### PR DESCRIPTION
In ns-dedalo path, the `/sbin/uci get system.@system[0].timezone` command returns a string that is not valid for authentication to my.nethspot.com on `wax`.

The current string is in the format: `CET-1CEST,M3.5.0,M10.5.0/3` while it should be in the format `Europe/Rome`.

Using `zonename` instead of `timezone` solves this problem.