### PR TITLE
packages: add netdata

### DIFF
--- a/config/netdata.conf
+++ b/config/netdata.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_netdata=y

--- a/patches/feeds/packages/100-netdata-export-promethus.patch
+++ b/patches/feeds/packages/100-netdata-export-promethus.patch
@@ -1,0 +1,12 @@
+diff --git a/admin/netdata/Makefile b/admin/netdata/Makefile
+index e471f27b2..def44a874 100644
+--- a/admin/netdata/Makefile
++++ b/admin/netdata/Makefile
+@@ -62,7 +62,6 @@ CONFIGURE_ARGS += \
+ 	--disable-plugin-freeipmi \
+ 	--disable-plugin-cups \
+ 	--disable-plugin-xenstat \
+-	--disable-backend-prometheus-remote-write \
+ 	--disable-unit-tests \
+ 	--disable-ml \
+ 	--disable-cloud


### PR DESCRIPTION
Add Netdata to expose metrics in real time.
This is a modified version of netdata upstream package which enable prometheus export.

Netdata UI is available at `http://<server_ip>:19999`.
Prometheus export is available at `http:///<server_ip>:19999/api/v1/allmetrics?format=prometheus&help=yes`
