### PR TITLE
ns-threat_shield: force ts-dns execution

### DIFF
--- a/packages/ns-threat_shield/README.md
+++ b/packages/ns-threat_shield/README.md
@@ -123,14 +123,12 @@ uci add_list adblock.global.adb_sources=yoroi_malware_level1
 uci add_list adblock.global.adb_sources=yoroi_malware_level2
 uci add_list adblock.global.adb_sources=yoroi_susp_level1
 uci add_list adblock.global.adb_sources=yoroi_susp_level2
-ts-dns
 /etc/init.d/adblock start
 ```
 
 Keep adblock enabled but disable threat shield categories:
 ```
 uci set adblock.global.ts_enabled=0
-ts-dns
 /etc/init.d/adblock reload
 ```
 

--- a/patches/feeds/packages/100-adblock-start-tsdns.patch
+++ b/patches/feeds/packages/100-adblock-start-tsdns.patch
@@ -1,0 +1,30 @@
+diff --git a/net/adblock/files/adblock.init b/net/adblock/files/adblock.init
+index 947e2f6ce..b68e8a4cb 100755
+--- a/net/adblock/files/adblock.init
++++ b/net/adblock/files/adblock.init
+@@ -33,6 +33,7 @@ boot() {
+ 
+ start_service() {
+ 	if "${adb_init}" enabled; then
++		/usr/sbin/ts-dns # configure threat shield dns, if needed
+ 		if [ "${action}" = "boot" ]; then
+ 			[ -n "$(uci_get adblock global adb_trigger)" ] && return 0
+ 		fi
+@@ -47,14 +48,17 @@ start_service() {
+ }
+ 
+ reload_service() {
++	/usr/sbin/ts-dns # configure threat shield dns, if needed
+ 	rc_procd start_service reload
+ }
+ 
+ stop_service() {
++	/usr/sbin/ts-dns # configure threat shield dns, if needed
+ 	rc_procd "${adb_script}" stop
+ }
+ 
+ restart() {
++	/usr/sbin/ts-dns # configure threat shield dns, if needed
+ 	rc_procd start_service restart
+ }
+ 


### PR DESCRIPTION
Make sure ts-dns is always executed, even after firmware flash. Otherwise after flashing, adblock will not start because /etc/adblock/combined.sources.gz is missing